### PR TITLE
[DEPLOY] v.47 Map, Notification, Stamp Refactoring

### DIFF
--- a/src/main/java/com/assu/server/domain/notification/entity/Notification.java
+++ b/src/main/java/com/assu/server/domain/notification/entity/Notification.java
@@ -33,8 +33,7 @@ public class Notification extends BaseEntity {
 	@Column(nullable = false, length = 40)
 	private NotificationType type;
 
-	@NotNull
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private Long refId;
 
 	@NotNull

--- a/src/main/java/com/assu/server/domain/notification/entity/OutboxCreatedEvent.java
+++ b/src/main/java/com/assu/server/domain/notification/entity/OutboxCreatedEvent.java
@@ -1,10 +1,15 @@
 package com.assu.server.domain.notification.entity;
 
-import com.assu.server.domain.notification.entity.Notification;
 import lombok.Value;
 
 @Value
 public class OutboxCreatedEvent {
     Long outboxId;
-    Notification notification;
+    Long receiverId;
+    String title;
+    String messagePreview;
+    String type;
+    Long refId;
+    String deeplink;
+    Long notificationId;
 }

--- a/src/main/java/com/assu/server/domain/notification/service/OutboxAfterCommitPublisher.java
+++ b/src/main/java/com/assu/server/domain/notification/service/OutboxAfterCommitPublisher.java
@@ -22,30 +22,25 @@ public class OutboxAfterCommitPublisher {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onOutboxCreated(OutboxCreatedEvent e) {
-        var n = e.getNotification();
-
         var dto = new NotificationMessageDTO(
                 String.valueOf(e.getOutboxId()),
-                n.getReceiver().getId(),
-                n.getTitle(),
-                n.getMessagePreview(),
+                e.getReceiverId(),
+                e.getTitle(),
+                e.getMessagePreview(),
                 Map.of(
-                        "type", n.getType().name(),
-                        "refId", String.valueOf(n.getRefId()),
-                        "deeplink", n.getDeeplink() == null ? "" : n.getDeeplink(),
-                        "notificationId", String.valueOf(n.getId())
+                        "type", e.getType(),
+                        "refId", e.getRefId() != null ? String.valueOf(e.getRefId()) : "",
+                        "deeplink", e.getDeeplink() == null ? "" : e.getDeeplink(),
+                        "notificationId", String.valueOf(e.getNotificationId())
                 )
         );
 
         try {
             rabbit.convertAndSend(AmqpConfig.EXCHANGE, AmqpConfig.ROUTING_KEY, dto);
             log.info("[Outbox] Message sent to queue for outboxId={}", e.getOutboxId());
-            // 메시지 전송 성공 시에만 상태 변경
             outboxStatus.markDispatched(e.getOutboxId());
         } catch (Exception ex) {
             log.error("[Outbox] Failed to send message for outboxId={}", e.getOutboxId(), ex);
-            // 전송 실패 시 상태는 PENDING으로 유지 (재시도 가능)
-            // 예외를 다시 던지지 않음으로써 트랜잭션 롤백을 방지
         }
     }
 }

--- a/src/main/java/com/assu/server/domain/notification/service/OutboxRetryProcessor.java
+++ b/src/main/java/com/assu/server/domain/notification/service/OutboxRetryProcessor.java
@@ -25,7 +25,17 @@ public class OutboxRetryProcessor {
             outbox.incrementRetryCount();
             outboxRepository.save(outbox);
             
-            OutboxCreatedEvent event = new OutboxCreatedEvent(outbox.getId(), outbox.getNotification());
+            var n = outbox.getNotification();
+            OutboxCreatedEvent event = new OutboxCreatedEvent(
+                    outbox.getId(),
+                    n.getReceiver().getId(),
+                    n.getTitle(),
+                    n.getMessagePreview(),
+                    n.getType().name(),
+                    n.getRefId(),
+                    n.getDeeplink(),
+                    n.getId()
+            );
             eventPublisher.publishEvent(event);
             
             log.debug("[OutboxRetry] Retrying outboxId={} retryCount={}", 

--- a/src/main/java/com/assu/server/domain/user/service/StudentServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/user/service/StudentServiceImpl.java
@@ -241,7 +241,11 @@ public class StudentServiceImpl implements StudentService {
 					.eventVersion("2026_SEASON_1")
 					.build();
 			stampEventApplicantRepository.save(applicant);
-			notificationCommandService.sendStamp(memberId);
+			try {
+				notificationCommandService.sendStamp(memberId);
+			} catch (Exception e) {
+				// 알림 전송 실패해도 스탬프 적립은 성공
+			}
 
 			student.resetStamp();
 			responseMessage = "스탬프 10개를 모아 자동 응모 되었습니다.";


### PR DESCRIPTION
## #️⃣연관된 이슈
> #274 

## 📝작업 내용
### 1. 맵 매장 조회 개선
- 기존: 전체 paper ID 기준으로 중복 제거 → 한 매장에 여러 제휴가 있어도 하나만 표시됨
- 수정: 매장별로 paper ID 중복 제거 → 각 매장의 모든 제휴가 표시됨

### 2. 알림 시스템 리팩토링
- Notification.refId를 nullable로 변경 (STAMP 타입 등 refId 불필요한 경우 대응)
- OutboxCreatedEvent에서 Notification 엔티티 참조 제거, 필요한 필드만 직접 전달
- sendIfEnabled 로직 수정 (알림 설정 활성화 또는 미설정 시 큐 전송, 비활성화 시 DB만 저장)
- OutboxAfterCommitPublisher에서 refId null 처리 추가
- 알림 전송 실패가 스탬프 적립을 롤백시키지 않도록 예외 처리 추가

### 3. 스탬프 이벤트 응모 자동화
- TemporaryQrServiceImpl에 스탬프 10의 배수(10, 20, 30...) 체크 로직 추가
- 10의 배수 달성 시 StampEventApplicant 저장 및 알림 전송 후 스탬프 초기화
- 제휴 사용 시에는 스탬프만 증가하고 이벤트 응모는 QR 인증 시에만 처리