### PR TITLE
[DEPLOY] v.49 사용 가능한 제휴 조회, 알림 재전송 로직 수정

### DIFF
--- a/src/main/java/com/assu/server/domain/notification/controller/NotificationTestController.java
+++ b/src/main/java/com/assu/server/domain/notification/controller/NotificationTestController.java
@@ -1,0 +1,23 @@
+package com.assu.server.domain.notification.controller;
+
+import com.assu.server.domain.notification.event.NotificationFailedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/test/notification")
+@RequiredArgsConstructor
+public class NotificationTestController {
+    
+    private final ApplicationEventPublisher eventPublisher;
+    
+    @PostMapping("/retry-test/{outboxId}")
+    public String testRetry(@PathVariable Long outboxId) {
+        log.info("[Test] Publishing retry event for outboxId: {}", outboxId);
+        eventPublisher.publishEvent(new NotificationFailedEvent(outboxId, 0));
+        return "Retry event published for outboxId: " + outboxId;
+    }
+}

--- a/src/main/java/com/assu/server/domain/notification/event/NotificationFailedEvent.java
+++ b/src/main/java/com/assu/server/domain/notification/event/NotificationFailedEvent.java
@@ -1,0 +1,11 @@
+package com.assu.server.domain.notification.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationFailedEvent {
+    private final Long outboxId;
+    private final int retryCount;
+}

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationListener.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationListener.java
@@ -1,5 +1,6 @@
 package com.assu.server.domain.notification.service;
 
+import com.assu.server.domain.notification.event.NotificationFailedEvent;
 import com.assu.server.infra.firebase.AmqpConfig;
 import com.assu.server.infra.firebase.FcmClient;
 import com.assu.server.domain.notification.dto.NotificationMessageDTO;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
@@ -20,6 +22,7 @@ public class NotificationListener {
 
     private final FcmClient fcmClient;
     private final OutboxStatusService outboxStatus;
+    private final ApplicationEventPublisher eventPublisher;
 
     @RabbitListener(queues = AmqpConfig.QUEUE, ackMode = "MANUAL")
     public void onMessage(@Payload NotificationMessageDTO notificationMessageDTO,
@@ -64,7 +67,15 @@ public class NotificationListener {
     }
 
     private void handleException(Exception e, Long outboxId, Long memberId) {
-        if (outboxId != null) outboxStatus.markFailed(outboxId);
+        if (outboxId != null) {
+            outboxStatus.markFailed(outboxId);
+            
+            // 일시적 실패인 경우에만 재시도 이벤트 발행
+            if (isRetryable(e)) {
+                eventPublisher.publishEvent(new NotificationFailedEvent(outboxId, 0));
+                log.info("[Notify] Scheduled retry for outboxId={}", outboxId);
+            }
+        }
 
         if (e instanceof FirebaseMessagingException fme) {
             handleFcmException(fme, outboxId, memberId);
@@ -85,6 +96,17 @@ public class NotificationListener {
         log.error("[Notify] FCM failure outboxId={} memberId={} root={} [permanent={} http={} code={}]",
                 outboxId, memberId, rootSummary(fme),
                 permanent, FcmClient.httpStatusOf(fme), fme.getMessagingErrorCode(), fme);
+    }
+
+    private boolean isRetryable(Exception e) {
+        if (e instanceof FirebaseMessagingException fme) {
+            return !isPermanent(fme);
+        }
+        // 네트워크, 타임아웃 등은 재시도 가능
+        return e instanceof java.net.UnknownHostException ||
+               e instanceof javax.net.ssl.SSLHandshakeException ||
+               e instanceof java.util.concurrent.TimeoutException ||
+               e instanceof java.net.SocketTimeoutException;
     }
 
     private boolean isPermanent(FirebaseMessagingException fme) {

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationRetryEventHandler.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationRetryEventHandler.java
@@ -1,0 +1,50 @@
+package com.assu.server.domain.notification.service;
+
+import com.assu.server.domain.notification.entity.NotificationOutbox;
+import com.assu.server.domain.notification.event.NotificationFailedEvent;
+import com.assu.server.domain.notification.repository.NotificationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationRetryEventHandler {
+    
+    private final NotificationOutboxRepository outboxRepository;
+    private final OutboxRetryProcessor retryProcessor;
+    
+    @EventListener
+    @Async
+    public void handleNotificationFailed(NotificationFailedEvent event) {
+        if (event.getRetryCount() >= 3) {
+            log.warn("[NotificationRetry] Max retry count reached for outbox: {}", event.getOutboxId());
+            return;
+        }
+        
+        // Exponential backoff: 30초, 60초, 120초
+        long delaySeconds = 30L * (1L << event.getRetryCount());
+        
+        log.info("[NotificationRetry] Scheduling retry for outbox: {} in {} seconds", 
+                event.getOutboxId(), delaySeconds);
+        
+        Executors.newSingleThreadScheduledExecutor()
+            .schedule(() -> {
+                try {
+                    NotificationOutbox outbox = outboxRepository.findById(event.getOutboxId())
+                        .orElse(null);
+                    if (outbox != null && outbox.getStatus() == NotificationOutbox.Status.PENDING) {
+                        retryProcessor.processRetry(outbox);
+                    }
+                } catch (Exception e) {
+                    log.error("[NotificationRetry] Error during retry for outbox: {}", event.getOutboxId(), e);
+                }
+            }, delaySeconds, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/assu/server/domain/notification/service/OutboxAfterCommitPublisher.java
+++ b/src/main/java/com/assu/server/domain/notification/service/OutboxAfterCommitPublisher.java
@@ -3,10 +3,12 @@ package com.assu.server.domain.notification.service;
 
 import com.assu.server.domain.notification.dto.NotificationMessageDTO;
 import com.assu.server.domain.notification.entity.OutboxCreatedEvent;
+import com.assu.server.domain.notification.event.NotificationFailedEvent;
 import com.assu.server.infra.firebase.AmqpConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -19,6 +21,7 @@ import java.util.Map;
 public class OutboxAfterCommitPublisher {
     private final RabbitTemplate rabbit;
     private final OutboxStatusService outboxStatus;
+    private final ApplicationEventPublisher eventPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onOutboxCreated(OutboxCreatedEvent e) {
@@ -41,6 +44,8 @@ public class OutboxAfterCommitPublisher {
             outboxStatus.markDispatched(e.getOutboxId());
         } catch (Exception ex) {
             log.error("[Outbox] Failed to send message for outboxId={}", e.getOutboxId(), ex);
+            // 큐 전송 실패 시 재시도 이벤트 발행
+            eventPublisher.publishEvent(new NotificationFailedEvent(e.getOutboxId(), 0));
         }
     }
 }

--- a/src/main/java/com/assu/server/domain/notification/service/OutboxRetryProcessor.java
+++ b/src/main/java/com/assu/server/domain/notification/service/OutboxRetryProcessor.java
@@ -2,6 +2,7 @@ package com.assu.server.domain.notification.service;
 
 import com.assu.server.domain.notification.entity.NotificationOutbox;
 import com.assu.server.domain.notification.entity.OutboxCreatedEvent;
+import com.assu.server.domain.notification.event.NotificationFailedEvent;
 import com.assu.server.domain.notification.repository.NotificationOutboxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +44,11 @@ public class OutboxRetryProcessor {
                 
         } catch (Exception e) {
             log.error("[OutboxRetry] Failed to retry outboxId={}", outbox.getId(), e);
+            
+            // 재시도 실패 시 이벤트 발행
+            if (outbox.getRetryCount() < 3) {
+                eventPublisher.publishEvent(new NotificationFailedEvent(outbox.getId(), outbox.getRetryCount()));
+            }
         }
     }
 }

--- a/src/main/java/com/assu/server/domain/notification/service/OutboxRetryScheduler.java
+++ b/src/main/java/com/assu/server/domain/notification/service/OutboxRetryScheduler.java
@@ -1,10 +1,13 @@
 package com.assu.server.domain.notification.service;
 
 import com.assu.server.domain.notification.entity.NotificationOutbox;
+import com.assu.server.domain.notification.event.NotificationFailedEvent;
 import com.assu.server.domain.notification.repository.NotificationOutboxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -16,22 +19,24 @@ public class OutboxRetryScheduler {
     
     private final NotificationOutboxRepository outboxRepository;
     private final OutboxRetryProcessor retryProcessor;
-    
-    @Scheduled(fixedDelay = 30000)
-    public void retryPendingNotifications() {
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 초기 시작 시 PENDING 상태인 알림들을 이벤트로 처리
+    @EventListener(ApplicationReadyEvent.class)
+    public void handleApplicationReady() {
         try {
             List<NotificationOutbox> pendingOutboxes = outboxRepository.findByStatusAndRetryCountLessThan(
                 NotificationOutbox.Status.PENDING, 3);
             
+            for (NotificationOutbox outbox : pendingOutboxes) {
+                eventPublisher.publishEvent(new NotificationFailedEvent(outbox.getId(), outbox.getRetryCount()));
+            }
+            
             if (!pendingOutboxes.isEmpty()) {
-                log.info("[OutboxRetry] Found {} pending notifications to retry", pendingOutboxes.size());
-                
-                for (NotificationOutbox outbox : pendingOutboxes) {
-                    retryProcessor.processRetry(outbox);
-                }
+                log.info("[OutboxRetry] Scheduled {} pending notifications on startup", pendingOutboxes.size());
             }
         } catch (Exception e) {
-            log.error("[OutboxRetry] Scheduler error", e);
+            log.error("[OutboxRetry] Error handling startup pending notifications", e);
         }
     }
 }

--- a/src/main/java/com/assu/server/domain/partnership/repository/GoodsRepository.java
+++ b/src/main/java/com/assu/server/domain/partnership/repository/GoodsRepository.java
@@ -12,6 +12,9 @@ public interface GoodsRepository extends JpaRepository<Goods, Long> {
 
 	List<Goods> findByContentId(Long contentId);
 
+	@Query("SELECT g FROM Goods g WHERE g.content.id IN :contentIds")
+	List<Goods> findByContentIdIn(@Param("contentIds") List<Long> contentIds);
+
     @Modifying
     @Query("delete from Goods g where g.content.id in :contentIds")
     void deleteAllByContentIds(@Param("contentIds") List<Long> contentIds);

--- a/src/main/java/com/assu/server/domain/partnership/repository/PaperContentRepository.java
+++ b/src/main/java/com/assu/server/domain/partnership/repository/PaperContentRepository.java
@@ -61,4 +61,6 @@ public interface PaperContentRepository extends JpaRepository<PaperContent, Long
         """, nativeQuery = true)
     List<PaperContent> findLatestByPaperIds(@Param("paperIds") List<Long> paperIds);
 
+    List<PaperContent> findByPaperIdIn(List<Long> paperIds);
+
 }

--- a/src/main/java/com/assu/server/domain/user/repository/UserPaperRepository.java
+++ b/src/main/java/com/assu/server/domain/user/repository/UserPaperRepository.java
@@ -24,4 +24,14 @@ public interface UserPaperRepository extends JpaRepository<UserPaper, Long> {
 
     boolean existsByStudentIdAndPaperId(Long studentId, Long paperId);
 
+    boolean existsByStudentIdAndPaperIdAndPaperContentId(Long studentId, Long paperId, Long paperContentId);
+
+    @Query("""
+        SELECT up FROM UserPaper up
+        JOIN FETCH up.paper p
+        JOIN FETCH up.paperContent pc
+        WHERE up.student.id = :studentId
+    """)
+    List<UserPaper> findByStudentId(@Param("studentId") Long studentId);
+
 }

--- a/src/main/java/com/assu/server/domain/user/service/StudentServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/user/service/StudentServiceImpl.java
@@ -3,7 +3,8 @@ package com.assu.server.domain.user.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import com.assu.server.domain.notification.service.NotificationCommandService;
 import com.assu.server.domain.user.entity.StampEventApplicant;
@@ -137,45 +138,40 @@ public class StudentServiceImpl implements StudentService {
 
 	@Override
 	public List<StudentResponseDTO.UsablePartnershipDTO> getUsablePartnership(Long memberId, Boolean all) {
-		LocalDate today = LocalDate.now();
+		List<UserPaper> userPapers = userPaperRepository.findActivePartnershipsByStudentId(memberId, LocalDate.now());
 
-		List<UserPaper> userPapers = userPaperRepository.findActivePartnershipsByStudentId(memberId, today);
+		// Goods 일괄 조회 (N+1 방지)
+		List<Long> contentIds = userPapers.stream()
+				.map(up -> up.getPaperContent().getId())
+				.toList();
+		Map<Long, List<Goods>> goodsMap = goodsRepository.findByContentIdIn(contentIds).stream()
+				.collect(Collectors.groupingBy(g -> g.getContent().getId()));
 
 		List<StudentResponseDTO.UsablePartnershipDTO> result = userPapers.stream().map(up -> {
 			Paper paper = up.getPaper();
 			PaperContent content = up.getPaperContent();
 			Store store = paper.getStore();
 
-			String adminName = (paper.getAdmin() != null) ? paper.getAdmin().getName() : null;
-			String partnerName = (store != null) ? store.getName() : null;
-
-			String finalCategory = null;
-			String note = null;
-			if (content != null) {
-				if(content.getNote() != null){
-					note = content.getNote();
-				}
-				if (content.getCategory() != null) {
-					finalCategory = content.getCategory();
-				} else if (content.getOptionType() == OptionType.SERVICE) {
-					List<Goods> goods = goodsRepository.findByContentId(content.getId());
-					if (!goods.isEmpty()) {
-						finalCategory = goods.get(0).getBelonging();
-					}
+			String finalCategory = content.getCategory();
+			if (finalCategory == null && content.getOptionType() == OptionType.SERVICE) {
+				List<Goods> goods = goodsMap.get(content.getId());
+				if (goods != null && !goods.isEmpty()) {
+					finalCategory = goods.get(0).getBelonging();
 				}
 			}
 
 			return StudentResponseDTO.UsablePartnershipDTO.builder()
 					.partnershipId(paper.getId())
-					.adminName(adminName)
-					.partnerName(partnerName)
-					.note(note).paperId(content != null? content.getPaper().getId(): null)
-					.criterionType(content != null ? content.getCriterionType() : null)
-					.optionType(content != null ? content.getOptionType() : null)
-					.people(content != null ? content.getPeople() : null)
-					.cost(content != null ? content.getCost() : null)
+					.adminName(paper.getAdmin() != null ? paper.getAdmin().getName() : null)
+					.partnerName(store != null ? store.getName() : null)
+					.note(content.getNote())
+					.paperId(paper.getId())
+					.criterionType(content.getCriterionType())
+					.optionType(content.getOptionType())
+					.people(content.getPeople())
+					.cost(content.getCost())
 					.category(finalCategory)
-					.discountRate(content != null ? content.getDiscount() : null)
+					.discountRate(content.getDiscount())
 					.build();
 		}).toList();
 
@@ -187,43 +183,41 @@ public class StudentServiceImpl implements StudentService {
 		Student student = studentRepository.findById(studentId)
 				.orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_STUDENT));
 
-		// 1. 학생 기준으로 admin 찾기
 		List<Admin> admins = adminRepository.findMatchingAdmins(
 				student.getUniversity(),
 				student.getDepartment(),
 				student.getMajor()
 		);
 
-		if (admins.isEmpty()) {
-			return;
-		}
+		if (admins.isEmpty()) return;
 
 		List<Long> adminIds = admins.stream().map(Admin::getId).toList();
-		LocalDate today = LocalDate.now();
-
-		// 2. admin들이 만든 오늘 유효한 paper 조회
 		List<Paper> papers = paperRepository.findActivePapersByAdminIds(
-				adminIds,
-				today,
-				ActivationStatus.ACTIVE
+				adminIds, LocalDate.now(), ActivationStatus.ACTIVE
 		);
 
-		// 3. user_paper에 없으면 넣기
-		for (Paper paper : papers) {
-			boolean exists = userPaperRepository.existsByStudentIdAndPaperId(studentId, paper.getId());
-			if (exists) continue;
+		if (papers.isEmpty()) return;
 
-			PaperContent latestContent = paperContentRepository
-					.findTopByPaperIdOrderByIdDesc(paper.getId())
-					.orElse(null);
+		List<Long> paperIds = papers.stream().map(Paper::getId).toList();
+		List<PaperContent> allContents = paperContentRepository.findByPaperIdIn(paperIds);
 
-			UserPaper up = UserPaper.builder()
-					.paper(paper)
-					.paperContent(latestContent)
-					.student(student)
-					.build();
+		// 기존 UserPaper 한 번에 조회 (N+1 방지)
+		List<UserPaper> existing = userPaperRepository.findByStudentId(studentId);
+		Set<String> existingKeys = existing.stream()
+				.map(up -> up.getPaper().getId() + "_" + up.getPaperContent().getId())
+				.collect(Collectors.toSet());
 
-			userPaperRepository.save(up);
+		List<UserPaper> newUserPapers = allContents.stream()
+				.filter(content -> !existingKeys.contains(content.getPaper().getId() + "_" + content.getId()))
+				.map(content -> UserPaper.builder()
+						.paper(content.getPaper())
+						.paperContent(content)
+						.student(student)
+						.build())
+				.toList();
+
+		if (!newUserPapers.isEmpty()) {
+			userPaperRepository.saveAll(newUserPapers);
 		}
 	}
 	@Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈
> #280 

## 📝작업 내용
- UserPaper 동기화 로직 수정
   - Paper 당 하나의 Paper Content만 들고 오던 기존 로직에서 모든 Paper Content를 들고 올 수 있도록 수정
- UserPaper 조회 로직 N+1 문제 해결
- 알림 재시도 시스템을 스케줄러 기반에서 이벤트 처리 기반으로 전환

## 🔎코드 설명(스크린샷(선택))
서버 재시작 또는 Pending 상태인 알림 발생시 재전송 최대 3번 진행
<img width="1461" height="50" alt="스크린샷 2026-03-03 오후 3 43 11" src="https://github.com/user-attachments/assets/c340631e-e0e4-4d48-832b-0571d3c8b3d9" />
