### PR TITLE
[REFACTOR/#283] 관리자별 다중 혜택 지원 기능 추가

### DIFF
--- a/src/main/java/com/assu/server/domain/map/dto/StoreMapResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/map/dto/StoreMapResponseDTO.java
@@ -47,7 +47,7 @@ public record StoreMapResponseDTO(
             Store store,
             Long adminId1, Long adminId2,
             String adminName1, String adminName2,
-            String benefit1, String benefit2,
+            List<String> benefits1, List<String> benefits2,
             AmazonS3Manager s3Manager
     ) {
         final boolean hasPartner = store.getPartner() != null;
@@ -62,10 +62,10 @@ public record StoreMapResponseDTO(
 
         List<PartnershipInfo> partnerships = new java.util.ArrayList<>();
         if (adminId1 != null) {
-            partnerships.add(new PartnershipInfo(adminId1, adminName1, List.of(benefit1)));
+            partnerships.add(new PartnershipInfo(adminId1, adminName1, benefits1));
         }
         if (adminId2 != null) {
-            partnerships.add(new PartnershipInfo(adminId2, adminName2, List.of(benefit2)));
+            partnerships.add(new PartnershipInfo(adminId2, adminName2, benefits2));
         }
 
         return new StoreMapResponseDTO(

--- a/src/main/java/com/assu/server/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/map/service/MapServiceImpl.java
@@ -140,15 +140,13 @@ public class MapServiceImpl implements MapService {
                 .map(Paper::getId)
                 .toList();
 
-        final Map<Long, PaperContent> contentByPaperId;
+        final Map<Long, List<PaperContent>> contentsByPaperId;
         if (selectedPaperIds.isEmpty()) {
-            contentByPaperId = Collections.emptyMap();
+            contentsByPaperId = Collections.emptyMap();
         } else {
-            contentByPaperId = paperContentRepository.findLatestByPaperIds(selectedPaperIds).stream()
-                    .collect(Collectors.toMap(
-                            pc -> pc.getPaper().getId(),
-                            pc -> pc,
-                            (a, b) -> a
+            contentsByPaperId = paperContentRepository.findByPaperIdIn(selectedPaperIds).stream()
+                    .collect(Collectors.groupingBy(
+                            pc -> pc.getPaper().getId()
                     ));
         }
 
@@ -160,10 +158,10 @@ public class MapServiceImpl implements MapService {
             Map<Long, List<String>> benefitsByAdmin = sPapers.stream()
                     .collect(Collectors.groupingBy(
                             paper -> paper.getAdmin().getId(),
-                            Collectors.mapping(
+                            Collectors.flatMapping(
                                     paper -> {
-                                        PaperContent content = contentByPaperId.get(paper.getId());
-                                        return resolveBenefit(content);
+                                        List<PaperContent> contents = contentsByPaperId.getOrDefault(paper.getId(), List.of());
+                                        return contents.stream().map(this::resolveBenefit);
                                     },
                                     Collectors.filtering(
                                             benefit -> benefit != null && !benefit.isBlank(),
@@ -261,15 +259,13 @@ public class MapServiceImpl implements MapService {
         Map<Long, List<Paper>> papersByStore = papers.stream()
                 .collect(Collectors.groupingBy(p -> p.getStore().getId()));
 
-        // 모든 paper의 최신 PaperContent 조회
+        // 모든 paper의 모든 PaperContent 조회
         List<Long> allPaperIds = papers.stream().map(Paper::getId).toList();
-        Map<Long, PaperContent> contentByPaperId = allPaperIds.isEmpty() 
+        Map<Long, List<PaperContent>> contentsByPaperId = allPaperIds.isEmpty() 
                 ? Collections.emptyMap()
-                : paperContentRepository.findLatestByPaperIds(allPaperIds).stream()
-                        .collect(Collectors.toMap(
-                                pc -> pc.getPaper().getId(),
-                                pc -> pc,
-                                (a, b) -> a
+                : paperContentRepository.findByPaperIdIn(allPaperIds).stream()
+                        .collect(Collectors.groupingBy(
+                                pc -> pc.getPaper().getId()
                         ));
 
         return storesWithActivePaper.stream().map(s -> {
@@ -279,10 +275,10 @@ public class MapServiceImpl implements MapService {
             Map<Long, List<String>> benefitsByAdmin = storePapers.stream()
                     .collect(Collectors.groupingBy(
                             paper -> paper.getAdmin().getId(),
-                            Collectors.mapping(
+                            Collectors.flatMapping(
                                     paper -> {
-                                        PaperContent content = contentByPaperId.get(paper.getId());
-                                        return resolveBenefit(content);
+                                        List<PaperContent> contents = contentsByPaperId.getOrDefault(paper.getId(), List.of());
+                                        return contents.stream().map(this::resolveBenefit);
                                     },
                                     Collectors.filtering(
                                             benefit -> benefit != null && !benefit.isBlank(),


### PR DESCRIPTION
## #️⃣연관된 이슈
> #283 

## 📝작업 내용
 - StoreMapResponseDTO.of 메서드가 단일 혜택 대신 혜택 리스트를 받도록 수정
 - MapServiceImpl에서 Paper당 최신 PaperContent 1개 대신 모든 PaperContent 조회하도록 변경
 - flatMapping을 사용하여 Paper별 여러 PaperContent의 모든 혜택 수집
 - 관리자가 여러 혜택을 가질 때 1개만 표시되던 문제 해결

## 🔎코드 설명(스크린샷(선택))
<img width="206" height="124" alt="스크린샷 2026-03-04 오후 2 32 16" src="https://github.com/user-attachments/assets/157560de-320b-4677-aaff-de563b95003f" />