### PR TITLE
[FEAT/#361] 백오피스 관리자, 제휴 관리 기능

### DIFF
--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
 import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateRequestDTO;
 import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateResponseDTO;
 import com.assu.server.domain.backoffice.dto.BackofficeAdminFetchResponseDTO;
@@ -39,6 +40,7 @@ public class BackofficeAdminController {
 		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.fetchAdmin());
 	}
 
+	@BackofficeAudited(action = "ADMIN_CREATE", targetId = "#req.email")
 	@Operation(summary = "학생회 계정 임의 추가 API", description = "인감 정보나 전화번호 없이 백오피스에서 임의로 학생회 계정을 추가합니다.")
 	@PostMapping
 	public BaseResponse<BackofficeAdminCreateResponseDTO> createAdmin(
@@ -47,6 +49,7 @@ public class BackofficeAdminController {
 		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.createAdmin(req));
 	}
 
+	@BackofficeAudited(action = "ADMIN_UPDATE", targetId = "#adminId")
 	@Operation(summary = "학생회 계정 임의 수정 API", description = "학생회(Admin) 계정 정보를 수정합니다. 입력된 필드만 반영됩니다.")
 	@PatchMapping("/{adminId}")
 	public BaseResponse<BackofficeAdminUpdateResponseDTO> updateAdmin(
@@ -56,6 +59,7 @@ public class BackofficeAdminController {
 		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.updateAdmin(adminId, req));
 	}
 
+	@BackofficeAudited(action = "ADMIN_DELETE", targetId = "#adminId")
 	@Operation(summary = "학생회 계정 임의 삭제 API", description = "학생회(Admin) 계정과 이에 연관된 모든 데이터(Member, CommonAuth)를 영구 삭제합니다.")
 	@DeleteMapping("/{adminId}")
 	public BaseResponse<Void> deleteAdmin(
@@ -65,4 +69,5 @@ public class BackofficeAdminController {
 		return BaseResponse.onSuccess(SuccessStatus._OK, null);
 	}
 }
+
 

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
@@ -1,0 +1,68 @@
+package com.assu.server.domain.backoffice.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminFetchResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminUpdateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminUpdateResponseDTO;
+import com.assu.server.domain.backoffice.service.BackofficeAdminService;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/admin")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficeAdminController {
+
+	private final BackofficeAdminService backofficeAdminService;
+
+	@Operation(summary = "모든 학생회 계정 조회 API", description = "시스템에 등록된 모든 학생회(Admin) 계정 목록을 조회합니다.")
+	@GetMapping
+	public BaseResponse<BackofficeAdminFetchResponseDTO> fetchAdmin() {
+		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.fetchAdmin());
+	}
+
+	@Operation(summary = "학생회 계정 임의 추가 API", description = "인감 정보나 전화번호 없이 백오피스에서 임의로 학생회 계정을 추가합니다.")
+	@PostMapping
+	public BaseResponse<BackofficeAdminCreateResponseDTO> createAdmin(
+		@RequestBody @Valid BackofficeAdminCreateRequestDTO req
+	) {
+		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.createAdmin(req));
+	}
+
+	@Operation(summary = "학생회 계정 임의 수정 API", description = "학생회(Admin) 계정 정보를 수정합니다. 입력된 필드만 반영됩니다.")
+	@PatchMapping("/{adminId}")
+	public BaseResponse<BackofficeAdminUpdateResponseDTO> updateAdmin(
+		@PathVariable Long adminId,
+		@RequestBody @Valid BackofficeAdminUpdateRequestDTO req
+	) {
+		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.updateAdmin(adminId, req));
+	}
+
+	@Operation(summary = "학생회 계정 임의 삭제 API", description = "학생회(Admin) 계정과 이에 연관된 모든 데이터(Member, CommonAuth)를 영구 삭제합니다.")
+	@DeleteMapping("/{adminId}")
+	public BaseResponse<Void> deleteAdmin(
+		@PathVariable Long adminId
+	) {
+		backofficeAdminService.deleteAdmin(adminId);
+		return BaseResponse.onSuccess(SuccessStatus._OK, null);
+	}
+}
+

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
@@ -21,6 +21,7 @@ import com.assu.server.global.apiPayload.BaseResponse;
 import com.assu.server.global.apiPayload.code.status.SuccessStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,14 +35,53 @@ public class BackofficeAdminController {
 
 	private final BackofficeAdminService backofficeAdminService;
 
-	@Operation(summary = "모든 학생회 계정 조회 API", description = "시스템에 등록된 모든 학생회(Admin) 계정 목록을 조회합니다.")
+	@Operation(
+			summary = "모든 학생회 계정 조회 API",
+			description = "시스템에 등록된 모든 학생회(Admin) 계정 목록을 조회합니다.\n\n" +
+					"**Response:**\n" +
+					"  - 성공 시 200(OK)과 `BackofficeAdminFetchResponseDTO` 객체 반환.\n" +
+					"  - `adminList` (List): 학생회 계정 목록\n" +
+					"    - `adminId` (Long): 학생회 ID\n" +
+					"    - `email` (String): 이메일 주소\n" +
+					"    - `name` (String): 이름\n" +
+					"    - `phoneNumber` (String): 전화번호\n" +
+					"    - `university` (University): 대학교 (CAU, etc.)\n" +
+					"    - `department` (Department): 학과 (ENGINEERING, etc.)\n" +
+					"    - `major` (Major): 전공 (CSE, etc.)\n" +
+					"    - `officeAddress` (String): 학생회실 주소\n" +
+					"    - `detailAddress` (String): 상세 주소\n" +
+					"    - `signImageUrl` (String): 서명 이미지 URL\n" +
+					"    - `isPhoneVerified` (Boolean): 전화번호 인증 여부\n"
+	)
 	@GetMapping
 	public BaseResponse<BackofficeAdminFetchResponseDTO> fetchAdmin() {
 		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.fetchAdmin());
 	}
 
 	@BackofficeAudited(action = "ADMIN_CREATE", targetId = "#req.email")
-	@Operation(summary = "학생회 계정 임의 추가 API", description = "인감 정보나 전화번호 없이 백오피스에서 임의로 학생회 계정을 추가합니다.")
+	@Operation(
+			summary = "학생회 계정 임의 추가 API",
+			description = "인감 정보나 전화번호 없이 백오피스에서 임의로 학생회 계정을 추가합니다.\n\n" +
+					"**Request Body:**\n" +
+					"  - `BackofficeAdminCreateRequest` 객체 (JSON, required)\n" +
+					"  - `email` (String, required): 이메일 주소\n" +
+					"  - `password` (String, required): 비밀번호\n" +
+					"  - `name` (String, required): 이름\n" +
+					"  - `phoneNumber` (String, optional): 전화번호\n" +
+					"  - `university` (University, required): 대학교 (CAU, etc.)\n" +
+					"  - `department` (Department, required): 학과 (ENGINEERING, etc.)\n" +
+					"  - `major` (Major, required): 전공 (CSE, etc.)\n" +
+					"  - `officeAddress` (String, optional): 학생회실 주소\n" +
+					"  - `detailAddress` (String, optional): 상세 주소\n" +
+					"  - `latitude` (Double, optional): 위도\n" +
+					"  - `longitude` (Double, optional): 경도\n\n" +
+					"**Response:**\n" +
+					"  - 성공 시 200(OK)과 `BackofficeAdminCreateResponseDTO` 객체 반환.\n" +
+					"  - `adminId` (Long): 생성된 학생회 ID\n" +
+					"  - `email` (String): 생성된 학생회 이메일\n" +
+					"  - `name` (String): 생성된 학생회 이름\n" +
+					"  - `createdAt` (LocalDateTime): 계정 생성 시간\n"
+	)
 	@PostMapping
 	public BaseResponse<BackofficeAdminCreateResponseDTO> createAdmin(
 		@RequestBody @Valid BackofficeAdminCreateRequestDTO req
@@ -50,20 +90,57 @@ public class BackofficeAdminController {
 	}
 
 	@BackofficeAudited(action = "ADMIN_UPDATE", targetId = "#adminId")
-	@Operation(summary = "학생회 계정 임의 수정 API", description = "학생회(Admin) 계정 정보를 수정합니다. 입력된 필드만 반영됩니다.")
+	@Operation(
+			summary = "학생회 계정 임의 수정 API",
+			description = "학생회(Admin) 계정 정보를 수정합니다. 입력된 필드만 반영됩니다.\n\n" +
+					"**Parameters:**\n" +
+					"  - `adminId` (Long, required): 수정할 학생회 ID\n\n" +
+					"**Request Body:**\n" +
+					"  - `BackofficeAdminUpdateRequest` 객체 (JSON, required)\n" +
+					"  - `email` (String, optional): 이메일 주소\n" +
+					"  - `password` (String, optional): 비밀번호\n" +
+					"  - `name` (String, optional): 이름\n" +
+					"  - `phoneNumber` (String, optional): 전화번호\n" +
+					"  - `university` (University, optional): 대학교\n" +
+					"  - `department` (Department, optional): 학과\n" +
+					"  - `major` (Major, optional): 전공\n" +
+					"  - `officeAddress` (String, optional): 학생회실 주소\n" +
+					"  - `detailAddress` (String, optional): 상세 주소\n" +
+					"  - `latitude` (Double, optional): 위도\n" +
+					"  - `longitude` (Double, optional): 경도\n\n" +
+					"**Response:**\n" +
+					"  - 성공 시 200(OK)과 `BackofficeAdminUpdateResponseDTO` 객체 반환.\n" +
+					"  - `adminId` (Long): 수정된 학생회 ID\n" +
+					"  - `email` (String): 수정된 이메일\n" +
+					"  - `name` (String): 수정된 이름\n" +
+					"  - `phoneNumber` (String): 수정된 전화번호\n" +
+					"  - `university` (University): 수정된 대학교\n" +
+					"  - `department` (Department): 수정된 학과\n" +
+					"  - `major` (Major): 수정된 전공\n" +
+					"  - `officeAddress` (String): 수정된 학생회실 주소\n" +
+					"  - `detailAddress` (String): 수정된 상세 주소\n" +
+					"  - `updatedAt` (LocalDateTime): 수정 완료 시간\n"
+	)
 	@PatchMapping("/{adminId}")
 	public BaseResponse<BackofficeAdminUpdateResponseDTO> updateAdmin(
-		@PathVariable Long adminId,
+		@PathVariable @Parameter(description = "수정할 학생회 ID", required = true) Long adminId,
 		@RequestBody @Valid BackofficeAdminUpdateRequestDTO req
 	) {
 		return BaseResponse.onSuccess(SuccessStatus._OK, backofficeAdminService.updateAdmin(adminId, req));
 	}
 
 	@BackofficeAudited(action = "ADMIN_DELETE", targetId = "#adminId")
-	@Operation(summary = "학생회 계정 임의 삭제 API", description = "학생회(Admin) 계정과 이에 연관된 모든 데이터(Member, CommonAuth)를 영구 삭제합니다.")
+	@Operation(
+			summary = "학생회 계정 임의 삭제 API",
+			description = "학생회(Admin) 계정과 이에 연관된 모든 데이터(Member, CommonAuth)를 영구 삭제합니다.\n\n" +
+					"**Parameters:**\n" +
+					"  - `adminId` (Long, required): 삭제할 학생회 ID\n\n" +
+					"**Response:**\n" +
+					"  - 성공 시 200(OK) 반환 (result=null)\n"
+	)
 	@DeleteMapping("/{adminId}")
 	public BaseResponse<Void> deleteAdmin(
-		@PathVariable Long adminId
+		@PathVariable @Parameter(description = "삭제할 학생회 ID", required = true) Long adminId
 	) {
 		backofficeAdminService.deleteAdmin(adminId);
 		return BaseResponse.onSuccess(SuccessStatus._OK, null);

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
@@ -1,0 +1,62 @@
+package com.assu.server.domain.backoffice.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.service.BackofficePaperService;
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/paper")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficePaperController {
+
+    private final BackofficePaperService backofficePaperService;
+
+    @BackofficeAudited(action = "PAPER_ALL_READ")
+    @Operation(summary = "모든 제휴 계약서 목록 조회 API (백오피스용)", description = "시스템에 등록된 모든 제휴 계약서 목록을 페이징 조회합니다.")
+    @GetMapping
+    public BaseResponse<Page<WritePartnershipResponseDTO>> getPapers(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficePaperService.getPapers(pageable));
+    }
+
+    @BackofficeAudited(action = "PAPER_APPROVE", targetId = "#paperId")
+    @Operation(summary = "제휴 계약서 승인 API (백오피스용)", description = "제휴 계약서를 승인하여 제휴 상태를 ACTIVE로 변경합니다.")
+    @PatchMapping("/{paperId}/approve")
+    public BaseResponse<Void> approvePaper(
+            @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId
+    ) {
+        backofficePaperService.approvePaper(paperId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, null);
+    }
+
+    @BackofficeAudited(action = "PAPER_REJECT", targetId = "#paperId")
+    @Operation(summary = "제휴 계약서 거부 API (백오피스용)", description = "제휴 계약서를 거부하여 제휴 상태를 INACTIVE로 변경합니다.")
+    @PatchMapping("/{paperId}/reject")
+    public BaseResponse<Void> rejectPaper(
+            @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId
+    ) {
+        backofficePaperService.rejectPaper(paperId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, null);
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
@@ -59,4 +59,15 @@ public class BackofficePaperController {
         backofficePaperService.rejectPaper(paperId);
         return BaseResponse.onSuccess(SuccessStatus._OK, null);
     }
+
+    @BackofficeAudited(action = "PAPER_EXPIRE", targetId = "#paperId")
+    @Operation(summary = "제휴 계약서 만료 API (백오피스용)", description = "제휴 계약서를 강제 만료하여 제휴 상태를 INACTIVE로 변경합니다.")
+    @PatchMapping("/{paperId}/expire")
+    public BaseResponse<Void> expirePaper(
+            @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId
+    ) {
+        backofficePaperService.expirePaper(paperId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, null);
+    }
 }
+

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
@@ -8,10 +8,14 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.dto.BackofficePaperContentCreateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePaperCreateRequestDTO;
 import com.assu.server.domain.backoffice.service.BackofficePaperService;
 import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
 import com.assu.server.global.apiPayload.BaseResponse;
@@ -20,6 +24,7 @@ import com.assu.server.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Backoffice", description = "백오피스 운영 API")
@@ -38,6 +43,27 @@ public class BackofficePaperController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return BaseResponse.onSuccess(SuccessStatus._OK, backofficePaperService.getPapers(pageable));
+    }
+
+    @BackofficeAudited(action = "PAPER_CREATE", targetId = "#req.adminId")
+    @Operation(summary = "임의의 제휴 계약서 생성 API (백오피스용)", description = "운영자가 임의의 제휴 계약서를 생성(빈 제휴 계약서)합니다.")
+    @PostMapping
+    public BaseResponse<WritePartnershipResponseDTO> createPaper(
+            @RequestBody @Valid BackofficePaperCreateRequestDTO req
+    ) {
+        WritePartnershipResponseDTO response = backofficePaperService.createPaper(req);
+        return BaseResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    @BackofficeAudited(action = "PAPER_CONTENT_ADD", targetId = "#paperId")
+    @Operation(summary = "제휴 계약서 내용(옵션) 추가 API (백오피스용)", description = "생성되어 있는 빈 제휴 계약서에 구체적인 제휴 혜택/옵션 및 Goods를 추가합니다.")
+    @PostMapping("/{paperId}/content")
+    public BaseResponse<WritePartnershipResponseDTO> addPaperContents(
+            @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId,
+            @RequestBody @Valid BackofficePaperContentCreateRequestDTO req
+    ) {
+        WritePartnershipResponseDTO response = backofficePaperService.addPaperContents(paperId, req);
+        return BaseResponse.onSuccess(SuccessStatus._OK, response);
     }
 
     @BackofficeAudited(action = "PAPER_APPROVE", targetId = "#paperId")

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePaperController.java
@@ -37,7 +37,33 @@ public class BackofficePaperController {
     private final BackofficePaperService backofficePaperService;
 
     @BackofficeAudited(action = "PAPER_ALL_READ")
-    @Operation(summary = "모든 제휴 계약서 목록 조회 API (백오피스용)", description = "시스템에 등록된 모든 제휴 계약서 목록을 페이징 조회합니다.")
+    @Operation(
+            summary = "모든 제휴 계약서 목록 조회 API (백오피스용)",
+            description = "시스템에 등록된 모든 제휴 계약서 목록을 페이징 조회합니다.\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
+                    "  - `partnershipId` (Long): 제안서 ID\n" +
+                    "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
+                    "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
+                    "  - `adminId` (Long): 관리자 ID\n" +
+                    "  - `partnerId` (Long): 제휴업체 ID\n" +
+                    "  - `storeId` (Long): 가게 ID\n" +
+                    "  - `storeName` (String): 가게 이름\n" +
+                    "  - `adminName` (String): 관리자 이름\n" +
+                    "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
+                    "  - `options` (JSON): 제휴 옵션\n" +
+                    "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                    "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                    "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                    "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                    "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                    "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                    "    - `category` (String): 서비스 카테고리\n" +
+                    "    - `discountRate` (Long): 할인율\n" +
+                    "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
+                    "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
+                    "      - `goodsName` (String): 서비스 제공 항목명\n"
+    )
     @GetMapping
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPapers(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -46,7 +72,18 @@ public class BackofficePaperController {
     }
 
     @BackofficeAudited(action = "PAPER_CREATE", targetId = "#req.adminId")
-    @Operation(summary = "임의의 제휴 계약서 생성 API (백오피스용)", description = "운영자가 임의의 제휴 계약서를 생성(빈 제휴 계약서)합니다.")
+    @Operation(
+            summary = "임의의 제휴 계약서 생성 API (백오피스용)",
+            description = "운영자가 임의의 제휴 계약서를 생성(빈 제휴 계약서)합니다.\n\n" +
+                    "**Request Body:**\n" +
+                    "  - `BackofficePaperCreateRequest` 객체 (JSON, required)\n" +
+                    "  - `adminId` (Long, required): 학생회 ID\n" +
+                    "  - `storeId` (Long, required): 가게 ID\n" +
+                    "  - `partnershipPeriodStart` (LocalDate, required): 제휴 시작일\n" +
+                    "  - `partnershipPeriodEnd` (LocalDate, required): 제휴 마감일\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK)과 생성된 `WritePartnershipResponse` 객체 반환. (상세 구조는 전체 조회 API의 Response 참조)\n"
+    )
     @PostMapping
     public BaseResponse<WritePartnershipResponseDTO> createPaper(
             @RequestBody @Valid BackofficePaperCreateRequestDTO req
@@ -56,7 +93,27 @@ public class BackofficePaperController {
     }
 
     @BackofficeAudited(action = "PAPER_CONTENT_ADD", targetId = "#paperId")
-    @Operation(summary = "제휴 계약서 내용(옵션) 추가 API (백오피스용)", description = "생성되어 있는 빈 제휴 계약서에 구체적인 제휴 혜택/옵션 및 Goods를 추가합니다.")
+    @Operation(
+            summary = "제휴 계약서 내용(옵션) 추가 API (백오피스용)",
+            description = "생성되어 있는 빈 제휴 계약서에 구체적인 제휴 혜택/옵션 및 Goods를 추가합니다.\n\n" +
+                    "**Parameters:**\n" +
+                    "  - `paperId` (Long, required): 계약서 ID\n\n" +
+                    "**Request Body:**\n" +
+                    "  - `BackofficePaperContentCreateRequest` 객체 (JSON, required)\n" +
+                    "  - `options` (JSON): 제휴 옵션 목록\n" +
+                    "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                    "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                    "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                    "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                    "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                    "    - `category` (String): 서비스 카테고리\n" +
+                    "    - `discountRate` (Long): 할인율\n" +
+                    "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                    "    - `goods` (JSON): 서비스 제공 항목\n" +
+                    "      - `goodsName` (String): 서비스 제공 항목명\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK)과 업데이트된 `WritePartnershipResponse` 객체 반환.\n"
+    )
     @PostMapping("/{paperId}/content")
     public BaseResponse<WritePartnershipResponseDTO> addPaperContents(
             @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId,
@@ -67,7 +124,14 @@ public class BackofficePaperController {
     }
 
     @BackofficeAudited(action = "PAPER_APPROVE", targetId = "#paperId")
-    @Operation(summary = "제휴 계약서 승인 API (백오피스용)", description = "제휴 계약서를 승인하여 제휴 상태를 ACTIVE로 변경합니다.")
+    @Operation(
+            summary = "제휴 계약서 승인 API (백오피스용)",
+            description = "제휴 계약서를 승인하여 제휴 상태를 ACTIVE로 변경합니다.\n\n" +
+                    "**Parameters:**\n" +
+                    "  - `paperId` (Long, required): 계약서 ID\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK) 반환 (result=null)\n"
+    )
     @PatchMapping("/{paperId}/approve")
     public BaseResponse<Void> approvePaper(
             @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId
@@ -77,7 +141,14 @@ public class BackofficePaperController {
     }
 
     @BackofficeAudited(action = "PAPER_REJECT", targetId = "#paperId")
-    @Operation(summary = "제휴 계약서 거부 API (백오피스용)", description = "제휴 계약서를 거부하여 제휴 상태를 INACTIVE로 변경합니다.")
+    @Operation(
+            summary = "제휴 계약서 거부 API (백오피스용)",
+            description = "제휴 계약서를 거부하여 제휴 상태를 INACTIVE로 변경합니다.\n\n" +
+                    "**Parameters:**\n" +
+                    "  - `paperId` (Long, required): 계약서 ID\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK) 반환 (result=null)\n"
+    )
     @PatchMapping("/{paperId}/reject")
     public BaseResponse<Void> rejectPaper(
             @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId
@@ -87,7 +158,14 @@ public class BackofficePaperController {
     }
 
     @BackofficeAudited(action = "PAPER_EXPIRE", targetId = "#paperId")
-    @Operation(summary = "제휴 계약서 만료 API (백오피스용)", description = "제휴 계약서를 강제 만료하여 제휴 상태를 INACTIVE로 변경합니다.")
+    @Operation(
+            summary = "제휴 계약서 만료 API (백오피스용)",
+            description = "제휴 계약서를 강제 만료하여 제휴 상태를 INACTIVE로 변경합니다.\n\n" +
+                    "**Parameters:**\n" +
+                    "  - `paperId` (Long, required): 계약서 ID\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK) 반환 (result=null)\n"
+    )
     @PatchMapping("/{paperId}/expire")
     public BaseResponse<Void> expirePaper(
             @PathVariable @Parameter(description = "계약서 ID", required = true) Long paperId

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
@@ -40,7 +40,6 @@ public class BackofficePartnershipController {
     }
 
     @BackofficeAudited(action = "PARTNERSHIP_BY_ADMIN_READ", targetId = "#adminId")
-
     @Operation(summary = "학생회별 제휴 목록 조회 API (백오피스용)", description = "특정 학생회 ID(adminId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.")
     @GetMapping("/admin/{adminId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByAdmin(
@@ -60,4 +59,3 @@ public class BackofficePartnershipController {
         return BaseResponse.onSuccess(SuccessStatus._OK, backofficePartnershipService.getPartnershipsByStore(storeId, pageable));
     }
 }
-

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
@@ -1,0 +1,63 @@
+package com.assu.server.domain.backoffice.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.service.BackofficePartnershipService;
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/partnership")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficePartnershipController {
+
+    private final BackofficePartnershipService backofficePartnershipService;
+
+    @BackofficeAudited(action = "PARTNERSHIP_ALL_READ")
+    @Operation(summary = "모든 제휴 목록 조회 API (백오피스용)", description = "시스템에 등록된 모든 제휴 목록을 페이징 조회합니다.")
+    @GetMapping
+    public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnerships(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficePartnershipService.getPartnerships(pageable));
+    }
+
+    @BackofficeAudited(action = "PARTNERSHIP_BY_ADMIN_READ", targetId = "#adminId")
+
+    @Operation(summary = "학생회별 제휴 목록 조회 API (백오피스용)", description = "특정 학생회 ID(adminId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.")
+    @GetMapping("/admin/{adminId}")
+    public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByAdmin(
+            @PathVariable @Parameter(description = "학생회 ID", required = true) Long adminId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficePartnershipService.getPartnershipsByAdmin(adminId, pageable));
+    }
+
+    @BackofficeAudited(action = "PARTNERSHIP_BY_STORE_READ", targetId = "#storeId")
+    @Operation(summary = "가게별 제휴 목록 조회 API (백오피스용)", description = "특정 가게 ID(storeId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.")
+    @GetMapping("/store/{storeId}")
+    public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByStore(
+            @PathVariable @Parameter(description = "가게 ID", required = true) Long storeId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficePartnershipService.getPartnershipsByStore(storeId, pageable));
+    }
+}
+

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
@@ -31,7 +31,33 @@ public class BackofficePartnershipController {
     private final BackofficePartnershipService backofficePartnershipService;
 
     @BackofficeAudited(action = "PARTNERSHIP_ALL_READ")
-    @Operation(summary = "모든 제휴 목록 조회 API (백오피스용)", description = "시스템에 등록된 모든 제휴 목록을 페이징 조회합니다.")
+    @Operation(
+            summary = "모든 제휴 목록 조회 API (백오피스용)",
+            description = "시스템에 등록된 모든 제휴 목록을 페이징 조회합니다.\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
+                    "  - `partnershipId` (Long): 제안서 ID\n" +
+                    "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
+                    "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
+                    "  - `adminId` (Long): 관리자 ID\n" +
+                    "  - `partnerId` (Long): 제휴업체 ID\n" +
+                    "  - `storeId` (Long): 가게 ID\n" +
+                    "  - `storeName` (String): 가게 이름\n" +
+                    "  - `adminName` (String): 관리자 이름\n" +
+                    "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
+                    "  - `options` (JSON): 제휴 옵션\n" +
+                    "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                    "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                    "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                    "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                    "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                    "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                    "    - `category` (String): 서비스 카테고리\n" +
+                    "    - `discountRate` (Long): 할인율\n" +
+                    "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
+                    "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
+                    "      - `goodsName` (String): 서비스 제공 항목명\n"
+    )
     @GetMapping
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnerships(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -40,7 +66,14 @@ public class BackofficePartnershipController {
     }
 
     @BackofficeAudited(action = "PARTNERSHIP_BY_ADMIN_READ", targetId = "#adminId")
-    @Operation(summary = "학생회별 제휴 목록 조회 API (백오피스용)", description = "특정 학생회 ID(adminId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.")
+    @Operation(
+            summary = "학생회별 제휴 목록 조회 API (백오피스용)",
+            description = "특정 학생회 ID(adminId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.\n\n" +
+                    "**Parameters:**\n" +
+                    "  - `adminId` (Long, required): 학생회 ID\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환. (상세 구조는 전체 조회 API의 Response 참조)\n"
+    )
     @GetMapping("/admin/{adminId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByAdmin(
             @PathVariable @Parameter(description = "학생회 ID", required = true) Long adminId,
@@ -50,7 +83,14 @@ public class BackofficePartnershipController {
     }
 
     @BackofficeAudited(action = "PARTNERSHIP_BY_STORE_READ", targetId = "#storeId")
-    @Operation(summary = "가게별 제휴 목록 조회 API (백오피스용)", description = "특정 가게 ID(storeId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.")
+    @Operation(
+            summary = "가게별 제휴 목록 조회 API (백오피스용)",
+            description = "특정 가게 ID(storeId) 기준 맺어진 활성화된 제휴 목록을 조회합니다.\n\n" +
+                    "**Parameters:**\n" +
+                    "  - `storeId` (Long, required): 가게 ID\n\n" +
+                    "**Response:**\n" +
+                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환. (상세 구조는 전체 조회 API의 Response 참조)\n"
+    )
     @GetMapping("/store/{storeId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByStore(
             @PathVariable @Parameter(description = "가게 ID", required = true) Long storeId,

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
@@ -72,7 +72,28 @@ public class BackofficePartnershipController {
                     "**Parameters:**\n" +
                     "  - `adminId` (Long, required): 학생회 ID\n\n" +
                     "**Response:**\n" +
-                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환. (상세 구조는 전체 조회 API의 Response 참조)\n"
+                "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
+                "  - `partnershipId` (Long): 제안서 ID\n" +
+                "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
+                "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
+                "  - `adminId` (Long): 관리자 ID\n" +
+                "  - `partnerId` (Long): 제휴업체 ID\n" +
+                "  - `storeId` (Long): 가게 ID\n" +
+                "  - `storeName` (String): 가게 이름\n" +
+                "  - `adminName` (String): 관리자 이름\n" +
+                "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
+                "  - `options` (JSON): 제휴 옵션\n" +
+                "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                "    - `category` (String): 서비스 카테고리\n" +
+                "    - `discountRate` (Long): 할인율\n" +
+                "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
+                "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
+                "      - `goodsName` (String): 서비스 제공 항목명\n"
     )
     @GetMapping("/admin/{adminId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByAdmin(
@@ -89,7 +110,28 @@ public class BackofficePartnershipController {
                     "**Parameters:**\n" +
                     "  - `storeId` (Long, required): 가게 ID\n\n" +
                     "**Response:**\n" +
-                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환. (상세 구조는 전체 조회 API의 Response 참조)\n"
+                "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
+                "  - `partnershipId` (Long): 제안서 ID\n" +
+                "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
+                "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
+                "  - `adminId` (Long): 관리자 ID\n" +
+                "  - `partnerId` (Long): 제휴업체 ID\n" +
+                "  - `storeId` (Long): 가게 ID\n" +
+                "  - `storeName` (String): 가게 이름\n" +
+                "  - `adminName` (String): 관리자 이름\n" +
+                "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
+                "  - `options` (JSON): 제휴 옵션\n" +
+                "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                "    - `category` (String): 서비스 카테고리\n" +
+                "    - `discountRate` (Long): 할인율\n" +
+                "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
+                "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
+                "      - `goodsName` (String): 서비스 제공 항목명\n"
     )
     @GetMapping("/store/{storeId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByStore(

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnershipController.java
@@ -72,28 +72,28 @@ public class BackofficePartnershipController {
                     "**Parameters:**\n" +
                     "  - `adminId` (Long, required): 학생회 ID\n\n" +
                     "**Response:**\n" +
-                "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
-                "  - `partnershipId` (Long): 제안서 ID\n" +
-                "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
-                "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
-                "  - `adminId` (Long): 관리자 ID\n" +
-                "  - `partnerId` (Long): 제휴업체 ID\n" +
-                "  - `storeId` (Long): 가게 ID\n" +
-                "  - `storeName` (String): 가게 이름\n" +
-                "  - `adminName` (String): 관리자 이름\n" +
-                "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
-                "  - `options` (JSON): 제휴 옵션\n" +
-                "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
-                "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
-                "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
-                "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
-                "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
-                "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
-                "    - `category` (String): 서비스 카테고리\n" +
-                "    - `discountRate` (Long): 할인율\n" +
-                "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
-                "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
-                "      - `goodsName` (String): 서비스 제공 항목명\n"
+                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
+                    "  - `partnershipId` (Long): 제안서 ID\n" +
+                    "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
+                    "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
+                    "  - `adminId` (Long): 관리자 ID\n" +
+                    "  - `partnerId` (Long): 제휴업체 ID\n" +
+                    "  - `storeId` (Long): 가게 ID\n" +
+                    "  - `storeName` (String): 가게 이름\n" +
+                    "  - `adminName` (String): 관리자 이름\n" +
+                    "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
+                    "  - `options` (JSON): 제휴 옵션\n" +
+                    "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                    "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                    "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                    "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                    "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                    "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                    "    - `category` (String): 서비스 카테고리\n" +
+                    "    - `discountRate` (Long): 할인율\n" +
+                    "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
+                    "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
+                    "      - `goodsName` (String): 서비스 제공 항목명\n"
     )
     @GetMapping("/admin/{adminId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByAdmin(
@@ -110,28 +110,28 @@ public class BackofficePartnershipController {
                     "**Parameters:**\n" +
                     "  - `storeId` (Long, required): 가게 ID\n\n" +
                     "**Response:**\n" +
-                "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
-                "  - `partnershipId` (Long): 제안서 ID\n" +
-                "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
-                "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
-                "  - `adminId` (Long): 관리자 ID\n" +
-                "  - `partnerId` (Long): 제휴업체 ID\n" +
-                "  - `storeId` (Long): 가게 ID\n" +
-                "  - `storeName` (String): 가게 이름\n" +
-                "  - `adminName` (String): 관리자 이름\n" +
-                "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
-                "  - `options` (JSON): 제휴 옵션\n" +
-                "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
-                "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
-                "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
-                "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
-                "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
-                "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
-                "    - `category` (String): 서비스 카테고리\n" +
-                "    - `discountRate` (Long): 할인율\n" +
-                "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
-                "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
-                "      - `goodsName` (String): 서비스 제공 항목명\n"
+                    "  - 성공 시 200(OK)과 `WritePartnershipResponse` 객체 목록(페이징) 반환.\n" +
+                    "  - `partnershipId` (Long): 제안서 ID\n" +
+                    "  - `partnershipPeriodStart` (LocalDate): 제휴 시작일\n" +
+                    "  - `partnershipPeriodEnd` (LocalDate): 제휴 마감일\n" +
+                    "  - `adminId` (Long): 관리자 ID\n" +
+                    "  - `partnerId` (Long): 제휴업체 ID\n" +
+                    "  - `storeId` (Long): 가게 ID\n" +
+                    "  - `storeName` (String): 가게 이름\n" +
+                    "  - `adminName` (String): 관리자 이름\n" +
+                    "  - `isActivated` (ActivationStatus): 제안서 활성화 여부\n" +
+                    "  - `options` (JSON): 제휴 옵션\n" +
+                    "    - `optionType` (OptionType): 제공 서비스 종류 (SERVICE/DISCOUNT)\n" +
+                    "    - `criterionType` (CriterionType): 서비스 제공 기준 (PRICE/HEADCOUNT)\n" +
+                    "    - `anotherType` (Boolean): 기타 제공 서비스 여부\n" +
+                    "    - `people` (Integer): 서비스 제공 기준 인원 수\n" +
+                    "    - `cost` (Integer): 서비스 제공 기준 금액\n" +
+                    "    - `note` (String): 기타 유형 제휴 옵션 문구\n" +
+                    "    - `category` (String): 서비스 카테고리\n" +
+                    "    - `discountRate` (Long): 할인율\n" +
+                    "    - `goods` (JSON): 서비스 제공 항목 목록\n" +
+                    "      - `goodsId` (Long): 서비스 제공 항목 ID\n" +
+                    "      - `goodsName` (String): 서비스 제공 항목명\n"
     )
     @GetMapping("/store/{storeId}")
     public BaseResponse<Page<WritePartnershipResponseDTO>> getPartnershipsByStore(

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminCreateRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminCreateRequestDTO.java
@@ -1,0 +1,40 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.common.entity.enums.Department;
+import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.entity.enums.University;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record BackofficeAdminCreateRequestDTO(
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    String password,
+
+    @NotBlank(message = "이름은 필수입니다.")
+    String name,
+
+    String phoneNumber,
+
+    @NotNull(message = "대학교는 필수입니다.")
+    University university,
+
+    @NotNull(message = "학과는 필수입니다.")
+    Department department,
+
+    @NotNull(message = "전공은 필수입니다.")
+    Major major,
+
+    String officeAddress,
+
+    String detailAddress,
+
+    Double latitude,
+
+    Double longitude
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminCreateResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminCreateResponseDTO.java
@@ -1,0 +1,11 @@
+package com.assu.server.domain.backoffice.dto;
+
+import java.time.LocalDateTime;
+
+public record BackofficeAdminCreateResponseDTO(
+    Long adminId,
+    String email,
+    String name,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminFetchResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminFetchResponseDTO.java
@@ -1,0 +1,46 @@
+package com.assu.server.domain.backoffice.dto;
+
+import java.util.List;
+
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.common.entity.enums.Department;
+import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.entity.enums.University;
+
+public record BackofficeAdminFetchResponseDTO(
+	List<BackofficeAdminInfoDTO> adminList
+) {
+	public record BackofficeAdminInfoDTO(
+		Long adminId,
+		String email,
+		String name,
+		String phoneNumber,
+		University university,
+		Department department,
+		Major major,
+		String officeAddress,
+		String detailAddress,
+		String signImageUrl,
+		Boolean isPhoneVerified
+	) {
+		public static BackofficeAdminInfoDTO from(Admin admin) {
+			String email = (admin.getMember() != null && admin.getMember().getCommonAuth() != null) 
+				? admin.getMember().getCommonAuth().getEmail() 
+				: null;
+			return new BackofficeAdminInfoDTO(
+				admin.getId(),
+				email,
+				admin.getName(),
+				admin.getPhoneNum(),
+				admin.getUniversity(),
+				admin.getDepartment(),
+				admin.getMajor(),
+				admin.getOfficeAddress(),
+				admin.getDetailAddress(),
+				admin.getSignImageUrl(),
+				admin.getIsPhoneVerified()
+			);
+		}
+	}
+
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminUpdateRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminUpdateRequestDTO.java
@@ -1,0 +1,32 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.common.entity.enums.Department;
+import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.entity.enums.University;
+import jakarta.validation.constraints.Email;
+
+public record BackofficeAdminUpdateRequestDTO(
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    String password,
+
+    String name,
+
+    String phoneNumber,
+
+    University university,
+
+    Department department,
+
+    Major major,
+
+    String officeAddress,
+
+    String detailAddress,
+
+    Double latitude,
+
+    Double longitude
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminUpdateResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminUpdateResponseDTO.java
@@ -1,0 +1,20 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.common.entity.enums.Department;
+import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.entity.enums.University;
+import java.time.LocalDateTime;
+
+public record BackofficeAdminUpdateResponseDTO(
+    Long adminId,
+    String email,
+    String name,
+    String phoneNumber,
+    University university,
+    Department department,
+    Major major,
+    String officeAddress,
+    String detailAddress,
+    LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePaperContentCreateRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePaperContentCreateRequestDTO.java
@@ -1,0 +1,11 @@
+package com.assu.server.domain.backoffice.dto;
+
+import java.util.List;
+import com.assu.server.domain.partnership.dto.PartnershipOptionRequestDTO;
+import jakarta.validation.constraints.NotNull;
+
+public record BackofficePaperContentCreateRequestDTO(
+    @NotNull(message = "제휴 옵션 목록은 필수입니다.")
+    List<PartnershipOptionRequestDTO> options
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePaperCreateRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePaperCreateRequestDTO.java
@@ -1,0 +1,19 @@
+package com.assu.server.domain.backoffice.dto;
+
+import java.time.LocalDate;
+import jakarta.validation.constraints.NotNull;
+
+public record BackofficePaperCreateRequestDTO(
+    @NotNull(message = "학생회 ID는 필수입니다.")
+    Long adminId,
+
+    @NotNull(message = "가게 ID는 필수입니다.")
+    Long storeId,
+
+    @NotNull(message = "제휴 시작일은 필수입니다.")
+    LocalDate partnershipPeriodStart,
+
+    @NotNull(message = "제휴 마감일은 필수입니다.")
+    LocalDate partnershipPeriodEnd
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePartnershipCreateRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePartnershipCreateRequestDTO.java
@@ -1,0 +1,40 @@
+package com.assu.server.domain.backoffice.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.assu.server.domain.map.dto.SelectedPlacePayload;
+import com.assu.server.domain.partnership.dto.PartnershipOptionRequestDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record BackofficePartnershipCreateRequestDTO(
+    @Schema(description = "학생회(Admin) ID", example = "1")
+    @NotNull(message = "학생회 ID는 필수입니다.")
+    Long adminId,
+
+    @Schema(description = "가게 이름", example = "역전할머니맥주 숭실대점")
+    @NotNull(message = "가게 이름은 필수입니다.")
+    String storeName,
+
+    @Schema(description = "선택된 장소 정보 (카카오맵 검색 결과)")
+    @NotNull(message = "장소 정보는 필수입니다.")
+    SelectedPlacePayload selectedPlace,
+
+    @Schema(description = "가게 상세주소", example = "2층")
+    String storeDetailAddress,
+
+    @Schema(description = "제휴 시작일", example = "2024-01-01")
+    @NotNull(message = "제휴 시작일은 필수입니다.")
+    LocalDate partnershipPeriodStart,
+
+    @Schema(description = "제휴 마감일", example = "2024-12-31")
+    @NotNull(message = "제휴 마감일은 필수입니다.")
+    LocalDate partnershipPeriodEnd,
+
+    @Schema(description = "제휴 옵션 목록")
+    @NotNull(message = "제휴 옵션 목록은 필수입니다.")
+    List<PartnershipOptionRequestDTO> options
+) {
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeAdminService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeAdminService.java
@@ -1,0 +1,18 @@
+package com.assu.server.domain.backoffice.service;
+
+import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminFetchResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminUpdateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminUpdateResponseDTO;
+
+public interface BackofficeAdminService {
+	BackofficeAdminFetchResponseDTO fetchAdmin();
+
+	BackofficeAdminCreateResponseDTO createAdmin(BackofficeAdminCreateRequestDTO req);
+
+	BackofficeAdminUpdateResponseDTO updateAdmin(Long adminId, BackofficeAdminUpdateRequestDTO req);
+
+	void deleteAdmin(Long adminId);
+}
+

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeAdminServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeAdminServiceImpl.java
@@ -1,0 +1,230 @@
+package com.assu.server.domain.backoffice.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.admin.repository.AdminRepository;
+import com.assu.server.domain.auth.entity.CommonAuth;
+import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.domain.auth.repository.CommonAuthRepository;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminCreateResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminFetchResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminUpdateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeAdminUpdateResponseDTO;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.member.repository.MemberRepository;
+import com.assu.server.domain.partner.repository.PartnerRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BackofficeAdminServiceImpl implements BackofficeAdminService {
+
+	private final AdminRepository adminRepository;
+	private final MemberRepository memberRepository;
+	private final CommonAuthRepository commonAuthRepository;
+	private final PartnerRepository partnerRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final GeometryFactory geometryFactory;
+
+	@Override
+	@Transactional(readOnly = true)
+	public BackofficeAdminFetchResponseDTO fetchAdmin() {
+		List<Admin> admins = adminRepository.findAll();
+		List<BackofficeAdminFetchResponseDTO.BackofficeAdminInfoDTO> adminInfoList = admins.stream()
+			.map(BackofficeAdminFetchResponseDTO.BackofficeAdminInfoDTO::from)
+			.collect(Collectors.toList());
+		return new BackofficeAdminFetchResponseDTO(adminInfoList);
+	}
+
+	@Override
+	public BackofficeAdminCreateResponseDTO createAdmin(BackofficeAdminCreateRequestDTO req) {
+		// 1) 이메일 중복 체크
+		if (commonAuthRepository.existsByEmail(req.email())) {
+			throw new CustomAuthException(ErrorStatus.EXISTED_EMAIL);
+		}
+
+		// 2) 휴대폰 번호 중복 체크 (전화번호가 기입된 경우만)
+		if (req.phoneNumber() != null && !req.phoneNumber().isBlank()) {
+			if (partnerRepository.existsByPhoneNum(req.phoneNumber())
+				|| adminRepository.existsByPhoneNum(req.phoneNumber())) {
+				throw new CustomAuthException(ErrorStatus.EXISTED_PHONE);
+			}
+		}
+
+		// 3) Member 엔티티 생성 및 저장
+		Member member = memberRepository.save(
+			Member.builder()
+				.isLocationTermAgreed(true)
+				.isMarketingTermAgreed(true)
+				.role(UserRole.ADMIN)
+				.isActivated(ActivationStatus.ACTIVE)
+				.build()
+		);
+
+		// 4) CommonAuth 생성 및 비밀번호 암호화 저장
+		String hashed = passwordEncoder.encode(req.password());
+		CommonAuth commonAuth = CommonAuth.builder()
+			.member(member)
+			.email(req.email())
+			.hashedPassword(hashed)
+			.lastLoginAt(LocalDateTime.now())
+			.build();
+		commonAuthRepository.save(commonAuth);
+		member.setCommonAuth(commonAuth);
+
+		// 5) officeAddress 기본값 처리
+		String address = req.officeAddress();
+		if (address == null || address.isBlank()) {
+			address = "미지정";
+		}
+
+		// 6) 위도/경도 데이터 및 Point 객체 생성
+		Double lat = req.latitude() != null ? req.latitude() : 0.0;
+		Double lng = req.longitude() != null ? req.longitude() : 0.0;
+		Point point = toPoint(lat, lng);
+
+		// 7) Admin 프로필 생성 및 저장
+		Admin admin = adminRepository.save(
+			Admin.builder()
+				.major(req.major())
+				.department(req.department())
+				.university(req.university())
+				.member(member)
+				.name(req.name())
+				.phoneNum(req.phoneNumber())
+				.isPhoneVerified(req.phoneNumber() != null && !req.phoneNumber().isBlank())
+				.officeAddress(address)
+				.detailAddress(req.detailAddress())
+				.signImageUrl(null) // 인감 이미지 미필수
+				.point(point)
+				.latitude(lat)
+				.longitude(lng)
+				.build()
+		);
+		member.setProfile(admin);
+
+		return new BackofficeAdminCreateResponseDTO(
+			member.getId(),
+			commonAuth.getEmail(),
+			admin.getName(),
+			member.getCreatedAt()
+		);
+	}
+
+	@Override
+	public BackofficeAdminUpdateResponseDTO updateAdmin(Long adminId, BackofficeAdminUpdateRequestDTO req) {
+		Admin admin = adminRepository.findById(adminId)
+			.orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+		Member member = admin.getMember();
+		CommonAuth commonAuth = member.getCommonAuth();
+
+		// 1) 이메일 변경 처리
+		if (req.email() != null && !req.email().isBlank() && !req.email().equals(commonAuth.getEmail())) {
+			if (commonAuthRepository.existsByEmail(req.email())) {
+				throw new CustomAuthException(ErrorStatus.EXISTED_EMAIL);
+			}
+			commonAuth.setEmail(req.email());
+		}
+
+		// 2) 비밀번호 변경 처리
+		if (req.password() != null && !req.password().isBlank()) {
+			String hashed = passwordEncoder.encode(req.password());
+			commonAuth.setHashedPassword(hashed);
+		}
+
+		// 3) 휴대폰 번호 변경 처리
+		if (req.phoneNumber() != null && !req.phoneNumber().equals(admin.getPhoneNum())) {
+			if (!req.phoneNumber().isBlank()) {
+				if (partnerRepository.existsByPhoneNum(req.phoneNumber())
+					|| adminRepository.existsByPhoneNum(req.phoneNumber())) {
+					throw new CustomAuthException(ErrorStatus.EXISTED_PHONE);
+				}
+				admin.setPhoneNum(req.phoneNumber());
+				admin.setIsPhoneVerified(true);
+			} else {
+				// 빈값으로 수정 시 null 및 미인증 처리
+				admin.setPhoneNum(null);
+				admin.setIsPhoneVerified(false);
+			}
+		}
+
+		// 4) 기타 프로필 정보 변경 처리
+		if (req.name() != null && !req.name().isBlank()) {
+			admin.setName(req.name());
+		}
+		if (req.university() != null) {
+			admin.setUniversity(req.university());
+		}
+		if (req.department() != null) {
+			admin.setDepartment(req.department());
+		}
+		if (req.major() != null) {
+			admin.setMajor(req.major());
+		}
+		if (req.officeAddress() != null) {
+			admin.setOfficeAddress(req.officeAddress());
+		}
+		if (req.detailAddress() != null) {
+			admin.setDetailAddress(req.detailAddress());
+		}
+
+		// 5) 위도/경도 변경 처리
+		if (req.latitude() != null || req.longitude() != null) {
+			Double lat = req.latitude() != null ? req.latitude() : admin.getLatitude();
+			Double lng = req.longitude() != null ? req.longitude() : admin.getLongitude();
+			admin.setLatitude(lat);
+			admin.setLongitude(lng);
+			admin.setPoint(toPoint(lat, lng));
+		}
+
+		commonAuthRepository.save(commonAuth);
+		adminRepository.save(admin);
+
+		return new BackofficeAdminUpdateResponseDTO(
+			admin.getId(),
+			commonAuth.getEmail(),
+			admin.getName(),
+			admin.getPhoneNum(),
+			admin.getUniversity(),
+			admin.getDepartment(),
+			admin.getMajor(),
+			admin.getOfficeAddress(),
+			admin.getDetailAddress(),
+			LocalDateTime.now()
+		);
+	}
+
+	@Override
+	public void deleteAdmin(Long adminId) {
+		Member member = memberRepository.findById(adminId)
+			.orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+		memberRepository.delete(member);
+	}
+
+	private Point toPoint(Double lat, Double lng) {
+		if (lat == null || lng == null) {
+			return null;
+		}
+		Point p = geometryFactory.createPoint(new Coordinate(lng, lat));
+		p.setSRID(4326);
+		return p;
+	}
+}
+

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
@@ -1,0 +1,79 @@
+package com.assu.server.domain.backoffice.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+import com.assu.server.domain.partnership.entity.Goods;
+import com.assu.server.domain.partnership.entity.Paper;
+import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.repository.PaperContentRepository;
+import com.assu.server.domain.partnership.repository.PaperRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BackofficePaperService {
+
+    private final PaperRepository paperRepository;
+    private final PaperContentRepository paperContentRepository;
+
+    @Transactional(readOnly = true)
+    public Page<WritePartnershipResponseDTO> getPapers(Pageable pageable) {
+        Page<Paper> paperPage = paperRepository.findAll(pageable);
+        List<Paper> papers = paperPage.getContent().stream()
+                .filter(p -> p.getAdmin() != null && p.getStore() != null)
+                .toList();
+        List<WritePartnershipResponseDTO> dtos = buildPartnershipDTOs(papers);
+        return new PageImpl<>(dtos, pageable, paperPage.getTotalElements());
+    }
+
+    public void approvePaper(Long paperId) {
+        Paper paper = paperRepository.findById(paperId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER)); // 혹은 NO_SUCH_PAPER 대체
+
+        paper.setIsActivated(ActivationStatus.ACTIVE);
+        paperRepository.save(paper);
+    }
+
+    public void rejectPaper(Long paperId) {
+        Paper paper = paperRepository.findById(paperId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+
+        paper.setIsActivated(ActivationStatus.INACTIVE);
+        paperRepository.save(paper);
+    }
+
+    private List<WritePartnershipResponseDTO> buildPartnershipDTOs(List<Paper> papers) {
+        if (papers == null || papers.isEmpty()) return List.of();
+
+        List<Long> paperIds = papers.stream().map(Paper::getId).toList();
+        List<PaperContent> allContents = paperContentRepository.findAllByPaperIdIn(paperIds, Pageable.unpaged()).getContent();
+
+        Map<Long, List<PaperContent>> byPaperId = allContents.stream()
+                .collect(Collectors.groupingBy(pc -> pc.getPaper().getId()));
+
+        List<WritePartnershipResponseDTO> result = new ArrayList<>(papers.size());
+        for (Paper p : papers) {
+            List<PaperContent> contents = byPaperId.getOrDefault(p.getId(), List.of());
+            List<List<Goods>> goodsBatches = contents.stream()
+                    .map(pc -> pc.getGoods() == null ? List.<Goods>of() : pc.getGoods())
+                    .toList();
+            result.add(WritePartnershipResponseDTO.of(p, contents, goodsBatches));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
@@ -57,6 +57,15 @@ public class BackofficePaperService {
         paperRepository.save(paper);
     }
 
+    public void expirePaper(Long paperId) {
+        Paper paper = paperRepository.findById(paperId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+
+        paper.setIsActivated(ActivationStatus.INACTIVE);
+        paperRepository.save(paper);
+    }
+
+
     private List<WritePartnershipResponseDTO> buildPartnershipDTOs(List<Paper> papers) {
         if (papers == null || papers.isEmpty()) return List.of();
 

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
@@ -11,14 +11,21 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.admin.repository.AdminRepository;
 import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.domain.backoffice.dto.BackofficePaperCreateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePaperContentCreateRequestDTO;
 import com.assu.server.domain.common.enums.ActivationStatus;
 import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
 import com.assu.server.domain.partnership.entity.Goods;
 import com.assu.server.domain.partnership.entity.Paper;
 import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.repository.GoodsRepository;
 import com.assu.server.domain.partnership.repository.PaperContentRepository;
 import com.assu.server.domain.partnership.repository.PaperRepository;
+import com.assu.server.domain.store.entity.Store;
+import com.assu.server.domain.store.repository.StoreRepository;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
@@ -26,10 +33,14 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class BackofficePaperService {
+public class
+BackofficePaperService {
 
     private final PaperRepository paperRepository;
     private final PaperContentRepository paperContentRepository;
+    private final AdminRepository adminRepository;
+    private final StoreRepository storeRepository;
+    private final GoodsRepository goodsRepository;
 
     @Transactional(readOnly = true)
     public Page<WritePartnershipResponseDTO> getPapers(Pageable pageable) {
@@ -43,7 +54,7 @@ public class BackofficePaperService {
 
     public void approvePaper(Long paperId) {
         Paper paper = paperRepository.findById(paperId)
-                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER)); // 혹은 NO_SUCH_PAPER 대체
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
 
         paper.setIsActivated(ActivationStatus.ACTIVE);
         paperRepository.save(paper);
@@ -65,6 +76,62 @@ public class BackofficePaperService {
         paperRepository.save(paper);
     }
 
+    public WritePartnershipResponseDTO createPaper(BackofficePaperCreateRequestDTO req) {
+        Admin admin = adminRepository.findById(req.adminId())
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+        Store store = storeRepository.findById(req.storeId())
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER)); // 가게 없을 시 예외
+
+        Paper paper = Paper.builder()
+                .admin(admin)
+                .store(store)
+                .partner(null)
+                .isActivated(ActivationStatus.ACTIVE) // 생성 시 ACTIVE 활성화 상태로 설정
+                .partnershipPeriodStart(req.partnershipPeriodStart())
+                .partnershipPeriodEnd(req.partnershipPeriodEnd())
+                .build();
+        paper = paperRepository.save(paper);
+
+        return WritePartnershipResponseDTO.of(paper, List.of(), List.of());
+    }
+
+    public WritePartnershipResponseDTO addPaperContents(Long paperId, BackofficePaperContentCreateRequestDTO req) {
+        Paper paper = paperRepository.findById(paperId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+
+        List<PaperContent> savedContents = new ArrayList<>();
+        if (req.options() != null && !req.options().isEmpty()) {
+            List<PaperContent> contents = new ArrayList<>(req.options().size());
+            for (var o : req.options()) {
+                contents.add(o.toPaperContent(paper));
+            }
+
+            for (int i = 0; i < contents.size(); i++) {
+                var opt = req.options().get(i);
+                if (opt.goods() != null && opt.goods().size() == 1) {
+                    contents.get(i).setCategory(opt.goods().get(0).goodsName());
+                }
+            }
+
+            savedContents = paperContentRepository.saveAll(contents);
+
+            List<Goods> toPersist = new ArrayList<>();
+            for (int i = 0; i < savedContents.size(); i++) {
+                var opt = req.options().get(i);
+                var content = savedContents.get(i);
+                var batch = opt.toGoods(content);
+                if (!batch.isEmpty()) toPersist.addAll(batch);
+            }
+            if (!toPersist.isEmpty()) goodsRepository.saveAll(toPersist);
+        }
+
+        List<PaperContent> contentsWithGoods = paperContentRepository.findAllByOnePaperIdInFetchGoods(paper.getId());
+        List<List<Goods>> goodsBatches = contentsWithGoods.stream()
+                .map(pc -> pc.getGoods() == null ? List.<Goods>of() : pc.getGoods())
+                .toList();
+
+        return WritePartnershipResponseDTO.of(paper, contentsWithGoods, goodsBatches);
+    }
 
     private List<WritePartnershipResponseDTO> buildPartnershipDTOs(List<Paper> papers) {
         if (papers == null || papers.isEmpty()) return List.of();

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePaperService.java
@@ -27,6 +27,7 @@ import com.assu.server.domain.partnership.repository.PaperRepository;
 import com.assu.server.domain.store.entity.Store;
 import com.assu.server.domain.store.repository.StoreRepository;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import com.assu.server.global.exception.DatabaseException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -56,6 +57,9 @@ BackofficePaperService {
         Paper paper = paperRepository.findById(paperId)
                 .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
 
+        if(paper.getIsActivated() == ActivationStatus.ACTIVE){
+            throw new DatabaseException(ErrorStatus.ALREADY_APPROVED);
+        }
         paper.setIsActivated(ActivationStatus.ACTIVE);
         paperRepository.save(paper);
     }
@@ -78,9 +82,9 @@ BackofficePaperService {
 
     public WritePartnershipResponseDTO createPaper(BackofficePaperCreateRequestDTO req) {
         Admin admin = adminRepository.findById(req.adminId())
-                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_MEMBER));
         Store store = storeRepository.findById(req.storeId())
-                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER)); // 가게 없을 시 예외
+                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_MEMBER)); // 가게 없을 시 예외
 
         Paper paper = Paper.builder()
                 .admin(admin)

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipService.java
@@ -10,4 +10,3 @@ public interface BackofficePartnershipService {
     Page<WritePartnershipResponseDTO> getPartnershipsByStore(Long storeId, Pageable pageable);
     Page<WritePartnershipResponseDTO> getPartnerships(Pageable pageable);
 }
-

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipService.java
@@ -1,0 +1,13 @@
+package com.assu.server.domain.backoffice.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+
+public interface BackofficePartnershipService {
+    Page<WritePartnershipResponseDTO> getPartnershipsByAdmin(Long adminId, Pageable pageable);
+    Page<WritePartnershipResponseDTO> getPartnershipsByStore(Long storeId, Pageable pageable);
+    Page<WritePartnershipResponseDTO> getPartnerships(Pageable pageable);
+}
+

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
@@ -47,7 +47,6 @@ public class BackofficePartnershipServiceImpl implements BackofficePartnershipSe
                 .toList();
         List<WritePartnershipResponseDTO> dtos = buildPartnershipDTOs(papers);
         return new PageImpl<>(dtos, pageable, paperPage.getTotalElements());
-
     }
 
     @Override
@@ -59,7 +58,6 @@ public class BackofficePartnershipServiceImpl implements BackofficePartnershipSe
         List<WritePartnershipResponseDTO> dtos = buildPartnershipDTOs(papers);
         return new PageImpl<>(dtos, pageable, paperPage.getTotalElements());
     }
-
 
     private List<WritePartnershipResponseDTO> buildPartnershipDTOs(List<Paper> papers) {
         if (papers == null || papers.isEmpty()) return List.of();

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
@@ -1,0 +1,83 @@
+package com.assu.server.domain.backoffice.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+import com.assu.server.domain.partnership.entity.Goods;
+import com.assu.server.domain.partnership.entity.Paper;
+import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.repository.PaperContentRepository;
+import com.assu.server.domain.partnership.repository.PaperRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BackofficePartnershipServiceImpl implements BackofficePartnershipService {
+
+    private final PaperRepository paperRepository;
+    private final PaperContentRepository paperContentRepository;
+
+    @Override
+    public Page<WritePartnershipResponseDTO> getPartnershipsByAdmin(Long adminId, Pageable pageable) {
+        Page<Paper> paperPage = paperRepository.findByAdmin_IdAndIsActivated(adminId, ActivationStatus.ACTIVE, pageable);
+        List<Paper> papers = paperPage.getContent().stream()
+                .filter(p -> p.getStore() != null)
+                .toList();
+        List<WritePartnershipResponseDTO> dtos = buildPartnershipDTOs(papers);
+        return new PageImpl<>(dtos, pageable, paperPage.getTotalElements());
+    }
+
+    @Override
+    public Page<WritePartnershipResponseDTO> getPartnershipsByStore(Long storeId, Pageable pageable) {
+        Page<Paper> paperPage = paperRepository.findByStore_IdAndIsActivated(storeId, ActivationStatus.ACTIVE, pageable);
+        List<Paper> papers = paperPage.getContent().stream()
+                .filter(p -> p.getAdmin() != null)
+                .toList();
+        List<WritePartnershipResponseDTO> dtos = buildPartnershipDTOs(papers);
+        return new PageImpl<>(dtos, pageable, paperPage.getTotalElements());
+
+    }
+
+    @Override
+    public Page<WritePartnershipResponseDTO> getPartnerships(Pageable pageable) {
+        Page<Paper> paperPage = paperRepository.findAll(pageable);
+        List<Paper> papers = paperPage.getContent().stream()
+                .filter(p -> p.getAdmin() != null && p.getStore() != null)
+                .toList();
+        List<WritePartnershipResponseDTO> dtos = buildPartnershipDTOs(papers);
+        return new PageImpl<>(dtos, pageable, paperPage.getTotalElements());
+    }
+
+
+    private List<WritePartnershipResponseDTO> buildPartnershipDTOs(List<Paper> papers) {
+        if (papers == null || papers.isEmpty()) return List.of();
+
+        List<Long> paperIds = papers.stream().map(Paper::getId).toList();
+        List<PaperContent> allContents = paperContentRepository.findAllByPaperIdIn(paperIds, Pageable.unpaged()).getContent();
+
+        Map<Long, List<PaperContent>> byPaperId = allContents.stream()
+                .collect(Collectors.groupingBy(pc -> pc.getPaper().getId()));
+
+        List<WritePartnershipResponseDTO> result = new ArrayList<>(papers.size());
+        for (Paper p : papers) {
+            List<PaperContent> contents = byPaperId.getOrDefault(p.getId(), List.of());
+            List<List<Goods>> goodsBatches = contents.stream()
+                    .map(pc -> pc.getGoods() == null ? List.<Goods>of() : pc.getGoods())
+                    .toList();
+            result.add(WritePartnershipResponseDTO.of(p, contents, goodsBatches));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
@@ -41,7 +41,7 @@ public class BackofficePartnershipServiceImpl implements BackofficePartnershipSe
 
     @Override
     public Page<WritePartnershipResponseDTO> getPartnershipsByStore(Long storeId, Pageable pageable) {
-        Page<Paper> paperPage = paperRepository.findByStore_IdAndIsActionStatus(storeId, ActivationStatus.ACTIVE, pageable);
+        Page<Paper> paperPage = paperRepository.findByStore_IdAndActivationStatus(storeId, ActivationStatus.ACTIVE, pageable);
         List<Paper> papers = paperPage.getContent().stream()
                 .filter(p -> p.getAdmin() != null)
                 .toList();

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficePartnershipServiceImpl.java
@@ -41,7 +41,7 @@ public class BackofficePartnershipServiceImpl implements BackofficePartnershipSe
 
     @Override
     public Page<WritePartnershipResponseDTO> getPartnershipsByStore(Long storeId, Pageable pageable) {
-        Page<Paper> paperPage = paperRepository.findByStore_IdAndIsActivated(storeId, ActivationStatus.ACTIVE, pageable);
+        Page<Paper> paperPage = paperRepository.findByStore_IdAndIsActionStatus(storeId, ActivationStatus.ACTIVE, pageable);
         List<Paper> papers = paperPage.getContent().stream()
                 .filter(p -> p.getAdmin() != null)
                 .toList();

--- a/src/main/java/com/assu/server/domain/partnership/repository/PaperRepository.java
+++ b/src/main/java/com/assu/server/domain/partnership/repository/PaperRepository.java
@@ -43,6 +43,8 @@ public interface PaperRepository extends JpaRepository<Paper, Long> {
     List<Paper> findByPartner_IdAndIsActivated(Long partnerId, ActivationStatus status, Sort sort);
     Page<Paper>  findByPartner_IdAndIsActivated(Long partnerId, ActivationStatus status, Pageable pageable);
     long countByStore_Id(Long storeId);
+    Page<Paper> findByStore_IdAndIsActivated(Long storeId, ActivationStatus status, Pageable pageable);
+
 
     @Query("""
         SELECT p FROM Paper p

--- a/src/main/java/com/assu/server/domain/partnership/repository/PaperRepository.java
+++ b/src/main/java/com/assu/server/domain/partnership/repository/PaperRepository.java
@@ -43,7 +43,7 @@ public interface PaperRepository extends JpaRepository<Paper, Long> {
     List<Paper> findByPartner_IdAndIsActivated(Long partnerId, ActivationStatus status, Sort sort);
     Page<Paper>  findByPartner_IdAndIsActivated(Long partnerId, ActivationStatus status, Pageable pageable);
     long countByStore_Id(Long storeId);
-    Page<Paper> findByStore_IdAndIsActivated(Long storeId, ActivationStatus status, Pageable pageable);
+    Page<Paper> findByStore_IdAndIsActionStatus(Long storeId, ActivationStatus status, Pageable pageable);
 
 
     @Query("""

--- a/src/main/java/com/assu/server/domain/partnership/repository/PaperRepository.java
+++ b/src/main/java/com/assu/server/domain/partnership/repository/PaperRepository.java
@@ -43,7 +43,13 @@ public interface PaperRepository extends JpaRepository<Paper, Long> {
     List<Paper> findByPartner_IdAndIsActivated(Long partnerId, ActivationStatus status, Sort sort);
     Page<Paper>  findByPartner_IdAndIsActivated(Long partnerId, ActivationStatus status, Pageable pageable);
     long countByStore_Id(Long storeId);
-    Page<Paper> findByStore_IdAndIsActionStatus(Long storeId, ActivationStatus status, Pageable pageable);
+
+    @Query("SELECT p FROM Paper p WHERE p.store.id = :storeId AND p.isActivated = :status")
+    Page<Paper> findByStore_IdAndActivationStatus(
+            @Param("storeId") Long storeId,
+            @Param("status") ActivationStatus status,
+            Pageable pageable
+    );
 
 
     @Query("""

--- a/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
@@ -67,6 +67,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 제휴 에러
     NO_SUCH_PAPER(HttpStatus.NOT_FOUND, "PAPER_9001", "제휴를 찾을 수 없습니다."),
     NO_SUCH_CONTENT(HttpStatus.NOT_FOUND, "PAPER_4002", "제휴 내용을 찾을 수 없습니다."),
+    ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "PAPER_4003", "이미 승인된 제휴 입니다."),
 
     // session 에러
     NO_SUCH_SESSION(HttpStatus.NOT_FOUND, "SESSION4001", "존재하지 않는 session ID입니다."),

--- a/src/test/java/com/assu/server/backoffice/BackofficePaperServiceTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePaperServiceTest.java
@@ -1,0 +1,118 @@
+package com.assu.server.backoffice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.backoffice.service.BackofficePaperService;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+import com.assu.server.domain.partnership.entity.Paper;
+import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.repository.PaperContentRepository;
+import com.assu.server.domain.partnership.repository.PaperRepository;
+import com.assu.server.domain.store.entity.Store;
+
+@ExtendWith(MockitoExtension.class)
+class BackofficePaperServiceTest {
+
+    @InjectMocks
+    private BackofficePaperService backofficePaperService;
+
+    @Mock
+    private PaperRepository paperRepository;
+
+    @Mock
+    private PaperContentRepository paperContentRepository;
+
+    @Test
+    @DisplayName("등록된 모든 제휴 계약서 목록을 페이징하여 조회한다")
+    void getPapers_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Admin admin = Admin.builder().id(1L).name("숭실학생회").build();
+        Store store = Store.builder().id(100L).name("역전할머니").build();
+
+        Paper paper = Paper.builder()
+                .id(10L)
+                .admin(admin)
+                .store(store)
+                .partnershipPeriodStart(LocalDate.now())
+                .partnershipPeriodEnd(LocalDate.now().plusDays(10))
+                .isActivated(ActivationStatus.SUSPEND)
+                .build();
+
+        Page<Paper> paperPage = new PageImpl<>(List.of(paper), pageable, 1);
+        when(paperRepository.findAll(any(Pageable.class))).thenReturn(paperPage);
+
+        Page<PaperContent> paperContentPage = new PageImpl<>(List.of());
+        when(paperContentRepository.findAllByPaperIdIn(any(), any())).thenReturn(paperContentPage);
+
+        // when
+        Page<WritePartnershipResponseDTO> response = backofficePaperService.getPapers(pageable);
+
+        // then
+        assertThat(response.getContent()).hasSize(1);
+        var dto = response.getContent().get(0);
+        assertThat(dto.partnershipId()).isEqualTo(10L);
+        assertThat(dto.isActivated()).isEqualTo(ActivationStatus.SUSPEND);
+    }
+
+    @Test
+    @DisplayName("제휴 계약서를 승인하여 ACTIVE 상태로 바꾼다")
+    void approvePaper_Success() {
+        // given
+        Long paperId = 10L;
+        Paper paper = Paper.builder()
+                .id(paperId)
+                .isActivated(ActivationStatus.SUSPEND)
+                .build();
+
+        when(paperRepository.findById(paperId)).thenReturn(Optional.of(paper));
+
+        // when
+        backofficePaperService.approvePaper(paperId);
+
+        // then
+        assertThat(paper.getIsActivated()).isEqualTo(ActivationStatus.ACTIVE);
+        verify(paperRepository).save(paper);
+    }
+
+    @Test
+    @DisplayName("제휴 계약서를 거부하여 INACTIVE 상태로 바꾼다")
+    void rejectPaper_Success() {
+        // given
+        Long paperId = 10L;
+        Paper paper = Paper.builder()
+                .id(paperId)
+                .isActivated(ActivationStatus.SUSPEND)
+                .build();
+
+        when(paperRepository.findById(paperId)).thenReturn(Optional.of(paper));
+
+        // when
+        backofficePaperService.rejectPaper(paperId);
+
+        // then
+        assertThat(paper.getIsActivated()).isEqualTo(ActivationStatus.INACTIVE);
+        verify(paperRepository).save(paper);
+    }
+}

--- a/src/test/java/com/assu/server/backoffice/BackofficePaperServiceTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePaperServiceTest.java
@@ -21,14 +21,23 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.admin.repository.AdminRepository;
+import com.assu.server.domain.backoffice.dto.BackofficePaperContentCreateRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePaperCreateRequestDTO;
 import com.assu.server.domain.backoffice.service.BackofficePaperService;
 import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.partnership.dto.PartnershipGoodsRequestDTO;
+import com.assu.server.domain.partnership.dto.PartnershipOptionRequestDTO;
 import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
 import com.assu.server.domain.partnership.entity.Paper;
 import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.entity.enums.CriterionType;
+import com.assu.server.domain.partnership.entity.enums.OptionType;
+import com.assu.server.domain.partnership.repository.GoodsRepository;
 import com.assu.server.domain.partnership.repository.PaperContentRepository;
 import com.assu.server.domain.partnership.repository.PaperRepository;
 import com.assu.server.domain.store.entity.Store;
+import com.assu.server.domain.store.repository.StoreRepository;
 
 @ExtendWith(MockitoExtension.class)
 class BackofficePaperServiceTest {
@@ -41,6 +50,15 @@ class BackofficePaperServiceTest {
 
     @Mock
     private PaperContentRepository paperContentRepository;
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private GoodsRepository goodsRepository;
 
     @Test
     @DisplayName("등록된 모든 제휴 계약서 목록을 페이징하여 조회한다")
@@ -134,6 +152,85 @@ class BackofficePaperServiceTest {
         // then
         assertThat(paper.getIsActivated()).isEqualTo(ActivationStatus.INACTIVE);
         verify(paperRepository).save(paper);
+    }
+
+    @Test
+    @DisplayName("임의의 제휴 계약서를 성공적으로 생성한다")
+    void createPaper_Success() {
+        // given
+        Long adminId = 1L;
+        Long storeId = 100L;
+        LocalDate start = LocalDate.now();
+        LocalDate end = LocalDate.now().plusDays(30);
+        BackofficePaperCreateRequestDTO req = new BackofficePaperCreateRequestDTO(adminId, storeId, start, end);
+
+        Admin admin = Admin.builder().id(adminId).name("숭실학생회").build();
+        Store store = Store.builder().id(storeId).name("역전할머니").build();
+        Paper paper = Paper.builder()
+                .id(10L)
+                .admin(admin)
+                .store(store)
+                .partnershipPeriodStart(start)
+                .partnershipPeriodEnd(end)
+                .isActivated(ActivationStatus.ACTIVE)
+                .build();
+
+        when(adminRepository.findById(adminId)).thenReturn(Optional.of(admin));
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        when(paperRepository.save(any(Paper.class))).thenReturn(paper);
+
+        // when
+        WritePartnershipResponseDTO response = backofficePaperService.createPaper(req);
+
+        // then
+        assertThat(response.partnershipId()).isEqualTo(10L);
+        assertThat(response.isActivated()).isEqualTo(ActivationStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("제휴 계약서에 제휴 내용(옵션)을 성공적으로 추가한다")
+    void addPaperContents_Success() {
+        // given
+        Long paperId = 10L;
+        Admin admin = Admin.builder().id(1L).name("숭실학생회").build();
+        Store store = Store.builder().id(100L).name("역전할머니").build();
+        Paper paper = Paper.builder()
+                .id(paperId)
+                .admin(admin)
+                .store(store)
+                .partnershipPeriodStart(LocalDate.now())
+                .partnershipPeriodEnd(LocalDate.now().plusDays(30))
+                .isActivated(ActivationStatus.ACTIVE)
+                .build();
+
+        PartnershipGoodsRequestDTO goodsReq = new PartnershipGoodsRequestDTO("제휴혜택상품");
+        PartnershipOptionRequestDTO optReq = new PartnershipOptionRequestDTO(
+                OptionType.SERVICE,
+                CriterionType.PRICE,
+                false,
+                null,
+                10000L,
+                "카테고리명",
+                null,
+                "혜택설명",
+                List.of(goodsReq)
+        );
+        BackofficePaperContentCreateRequestDTO req = new BackofficePaperContentCreateRequestDTO(List.of(optReq));
+
+        PaperContent paperContent = optReq.toPaperContent(paper);
+        List<PaperContent> savedContents = List.of(paperContent);
+
+        when(paperRepository.findById(paperId)).thenReturn(Optional.of(paper));
+        when(paperContentRepository.saveAll(any())).thenReturn(savedContents);
+        when(paperContentRepository.findAllByOnePaperIdInFetchGoods(paperId)).thenReturn(savedContents);
+
+        // when
+        WritePartnershipResponseDTO response = backofficePaperService.addPaperContents(paperId, req);
+
+        // then
+        assertThat(response.partnershipId()).isEqualTo(paperId);
+        verify(paperContentRepository).saveAll(any());
+        verify(goodsRepository).saveAll(any());
     }
 }
 

--- a/src/test/java/com/assu/server/backoffice/BackofficePaperServiceTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePaperServiceTest.java
@@ -115,4 +115,25 @@ class BackofficePaperServiceTest {
         assertThat(paper.getIsActivated()).isEqualTo(ActivationStatus.INACTIVE);
         verify(paperRepository).save(paper);
     }
+
+    @Test
+    @DisplayName("제휴 계약서를 만료 처리하여 INACTIVE 상태로 바꾼다")
+    void expirePaper_Success() {
+        // given
+        Long paperId = 10L;
+        Paper paper = Paper.builder()
+                .id(paperId)
+                .isActivated(ActivationStatus.ACTIVE)
+                .build();
+
+        when(paperRepository.findById(paperId)).thenReturn(Optional.of(paper));
+
+        // when
+        backofficePaperService.expirePaper(paperId);
+
+        // then
+        assertThat(paper.getIsActivated()).isEqualTo(ActivationStatus.INACTIVE);
+        verify(paperRepository).save(paper);
+    }
 }
+

--- a/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,14 +22,20 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.admin.repository.AdminRepository;
+import com.assu.server.domain.backoffice.dto.BackofficePartnershipCreateRequestDTO;
 import com.assu.server.domain.backoffice.service.BackofficePartnershipServiceImpl;
 import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.map.dto.SelectedPlacePayload;
 import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
 import com.assu.server.domain.partnership.entity.Paper;
 import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.repository.GoodsRepository;
 import com.assu.server.domain.partnership.repository.PaperContentRepository;
 import com.assu.server.domain.partnership.repository.PaperRepository;
 import com.assu.server.domain.store.entity.Store;
+import com.assu.server.domain.store.repository.StoreRepository;
+import com.assu.server.infra.s3.AmazonS3Manager;
 
 @ExtendWith(MockitoExtension.class)
 class BackofficePartnershipServiceImplTest {
@@ -40,6 +48,18 @@ class BackofficePartnershipServiceImplTest {
 
     @Mock
     private PaperContentRepository paperContentRepository;
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private GoodsRepository goodsRepository;
+
+    @Mock
+    private AmazonS3Manager amazonS3Manager;
 
     @Test
     @DisplayName("백오피스 전용: 특정 학생회 ID 기준 활성 제휴 목록을 정상 조회한다")

--- a/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
@@ -1,0 +1,152 @@
+package com.assu.server.backoffice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.backoffice.service.BackofficePartnershipServiceImpl;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
+import com.assu.server.domain.partnership.entity.Paper;
+import com.assu.server.domain.partnership.entity.PaperContent;
+import com.assu.server.domain.partnership.repository.PaperContentRepository;
+import com.assu.server.domain.partnership.repository.PaperRepository;
+import com.assu.server.domain.store.entity.Store;
+
+@ExtendWith(MockitoExtension.class)
+class BackofficePartnershipServiceImplTest {
+
+    @InjectMocks
+    private BackofficePartnershipServiceImpl backofficePartnershipService;
+
+    @Mock
+    private PaperRepository paperRepository;
+
+    @Mock
+    private PaperContentRepository paperContentRepository;
+
+    @Test
+    @DisplayName("백오피스 전용: 특정 학생회 ID 기준 활성 제휴 목록을 정상 조회한다")
+    void getPartnershipsByAdmin_Success() {
+        // given
+        Long adminId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Admin admin = Admin.builder().id(adminId).name("숭실학생회").build();
+        Store store = Store.builder().id(100L).name("역전할머니").build();
+
+        Paper paper = Paper.builder()
+                .id(10L)
+                .admin(admin)
+                .store(store)
+                .partnershipPeriodStart(LocalDate.now())
+                .partnershipPeriodEnd(LocalDate.now().plusDays(10))
+                .isActivated(ActivationStatus.ACTIVE)
+                .build();
+
+        Page<Paper> paperPage = new PageImpl<>(List.of(paper), pageable, 1);
+        when(paperRepository.findByAdmin_IdAndIsActivated(eq(adminId), eq(ActivationStatus.ACTIVE), any(Pageable.class)))
+                .thenReturn(paperPage);
+
+        Page<PaperContent> paperContentPage = new PageImpl<>(List.of());
+        when(paperContentRepository.findAllByPaperIdIn(any(), any())).thenReturn(paperContentPage);
+
+        // when
+        Page<WritePartnershipResponseDTO> response = backofficePartnershipService.getPartnershipsByAdmin(adminId, pageable);
+
+        // then
+        assertThat(response.getContent()).hasSize(1);
+        var dto = response.getContent().get(0);
+        assertThat(dto.partnershipId()).isEqualTo(10L);
+        assertThat(dto.storeName()).isEqualTo("역전할머니");
+        assertThat(dto.adminName()).isEqualTo("숭실학생회");
+    }
+
+    @Test
+    @DisplayName("백오피스 전용: 특정 가게 ID 기준 활성 제휴 목록을 정상 조회한다")
+    void getPartnershipsByStore_Success() {
+        // given
+        Long storeId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Admin admin = Admin.builder().id(1L).name("숭실학생회").build();
+        Store store = Store.builder().id(storeId).name("역전할머니").build();
+
+        Paper paper = Paper.builder()
+                .id(10L)
+                .admin(admin)
+                .store(store)
+                .partnershipPeriodStart(LocalDate.now())
+                .partnershipPeriodEnd(LocalDate.now().plusDays(10))
+                .isActivated(ActivationStatus.ACTIVE)
+                .build();
+
+        Page<Paper> paperPage = new PageImpl<>(List.of(paper), pageable, 1);
+        when(paperRepository.findByStore_IdAndIsActivated(eq(storeId), eq(ActivationStatus.ACTIVE), any(Pageable.class)))
+                .thenReturn(paperPage);
+
+        Page<PaperContent> paperContentPage = new PageImpl<>(List.of());
+        when(paperContentRepository.findAllByPaperIdIn(any(), any())).thenReturn(paperContentPage);
+
+        // when
+        Page<WritePartnershipResponseDTO> response = backofficePartnershipService.getPartnershipsByStore(storeId, pageable);
+
+        // then
+        assertThat(response.getContent()).hasSize(1);
+        var dto = response.getContent().get(0);
+        assertThat(dto.partnershipId()).isEqualTo(10L);
+        assertThat(dto.storeName()).isEqualTo("역전할머니");
+        assertThat(dto.adminName()).isEqualTo("숭실학생회");
+    }
+
+    @Test
+    @DisplayName("백오피스 전용: 등록된 모든 제휴 목록을 페이징하여 조회한다")
+    void getPartnerships_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Admin admin = Admin.builder().id(1L).name("숭실학생회").build();
+        Store store = Store.builder().id(100L).name("역전할머니").build();
+
+        Paper paper = Paper.builder()
+                .id(10L)
+                .admin(admin)
+                .store(store)
+                .partnershipPeriodStart(LocalDate.now())
+                .partnershipPeriodEnd(LocalDate.now().plusDays(10))
+                .isActivated(ActivationStatus.ACTIVE)
+                .build();
+
+        Page<Paper> paperPage = new PageImpl<>(List.of(paper), pageable, 1);
+        when(paperRepository.findAll(any(Pageable.class))).thenReturn(paperPage);
+
+        Page<PaperContent> paperContentPage = new PageImpl<>(List.of());
+        when(paperContentRepository.findAllByPaperIdIn(any(), any())).thenReturn(paperContentPage);
+
+        // when
+        Page<WritePartnershipResponseDTO> response = backofficePartnershipService.getPartnerships(pageable);
+
+        // then
+        assertThat(response.getContent()).hasSize(1);
+        var dto = response.getContent().get(0);
+        assertThat(dto.partnershipId()).isEqualTo(10L);
+        assertThat(dto.storeName()).isEqualTo("역전할머니");
+        assertThat(dto.adminName()).isEqualTo("숭실학생회");
+    }
+}

--- a/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +24,6 @@ import com.assu.server.domain.admin.entity.Admin;
 import com.assu.server.domain.admin.repository.AdminRepository;
 import com.assu.server.domain.backoffice.service.BackofficePartnershipServiceImpl;
 import com.assu.server.domain.common.enums.ActivationStatus;
-import com.assu.server.domain.map.dto.SelectedPlacePayload;
 import com.assu.server.domain.partnership.dto.WritePartnershipResponseDTO;
 import com.assu.server.domain.partnership.entity.Paper;
 import com.assu.server.domain.partnership.entity.PaperContent;
@@ -117,7 +115,7 @@ class BackofficePartnershipServiceImplTest {
                 .build();
 
         Page<Paper> paperPage = new PageImpl<>(List.of(paper), pageable, 1);
-        when(paperRepository.findByStore_IdAndIsActionStatus(eq(storeId), eq(ActivationStatus.ACTIVE), any(Pageable.class)))
+        when(paperRepository.findByStore_IdAndActivationStatus(eq(storeId), eq(ActivationStatus.ACTIVE), any(Pageable.class)))
                 .thenReturn(paperPage);
 
         Page<PaperContent> paperContentPage = new PageImpl<>(List.of());

--- a/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficePartnershipServiceImplTest.java
@@ -23,7 +23,6 @@ import org.springframework.data.domain.Pageable;
 
 import com.assu.server.domain.admin.entity.Admin;
 import com.assu.server.domain.admin.repository.AdminRepository;
-import com.assu.server.domain.backoffice.dto.BackofficePartnershipCreateRequestDTO;
 import com.assu.server.domain.backoffice.service.BackofficePartnershipServiceImpl;
 import com.assu.server.domain.common.enums.ActivationStatus;
 import com.assu.server.domain.map.dto.SelectedPlacePayload;
@@ -118,7 +117,7 @@ class BackofficePartnershipServiceImplTest {
                 .build();
 
         Page<Paper> paperPage = new PageImpl<>(List.of(paper), pageable, 1);
-        when(paperRepository.findByStore_IdAndIsActivated(eq(storeId), eq(ActivationStatus.ACTIVE), any(Pageable.class)))
+        when(paperRepository.findByStore_IdAndIsActionStatus(eq(storeId), eq(ActivationStatus.ACTIVE), any(Pageable.class)))
                 .thenReturn(paperPage);
 
         Page<PaperContent> paperContentPage = new PageImpl<>(List.of());


### PR DESCRIPTION
## #️⃣연관된 이슈
> #361

## 📝작업 내용
- 백오피스용 학생회(Admin) 계정 CRUD API 추가 (임의 생성/조회/수정/삭제)
- 백오피스용 제휴 계약서(Paper) 관리 API 추가 (임의 생성, 옵션/굿즈 내용 추가, 승인/거부/만료 처리, 페이징 조회)
- 백오피스용 제휴(Partnership) 조회 API 추가 (전체/학생회별/가게별 페이징 조회)
- 위 API들에 @BackofficeAudited 어노테이션 적용하여 감사 로그 기록
- 관련 Repository 메서드 추가 (findByStore_IdAndIsActivated 등)
- BackofficePaperService, BackofficePartnershipServiceImpl 관련 단위 테스트 작성

## 🔎코드 설명
- BackofficeAdminController/Service: 인감·전화번호 없이 백오피스에서 임의로 학생회 계정을 생성/수정/삭제할 수 있도록 함
- BackofficePaperController/Service: 계약서를 먼저 빈 상태로 생성한 뒤, 옵션/굿즈 내용을 별도 API로 추가하는 2단계 플로우로 설계
- BackofficePartnershipController/ServiceImpl: 조회 전용 API로, ACTIVE 상태인 제휴만 필터링해서 반환

## 💬고민사항 및 리뷰 요구사항
- deleteAdmin에서 하드 삭제 방식이 맞는지 (감사 로그와의 정합성 관련) 의견 부탁드립니다
- Paper 상태 전이(승인/거부/만료) 시 현재 상태에 대한 검증 없이 무조건 상태를 바꾸는데, 상태 검증 로직이 필요한지 확인 부탁드립니다

## 비고
-