### PR TITLE
[FEAT/#362] 백오피스 푸시 알림 그룹 발송 및 문의 키워드 검색 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ src/main/resources/application-prod.yml
 
 ### Firebase ###
 src/main/resources/firebase/
+
+### macOS ###
+.DS_Store
+**/.DS_Store
+
+### Node ###
+node_modules/

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeInquiryController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeInquiryController.java
@@ -2,18 +2,24 @@ package com.assu.server.domain.backoffice.controller;
 
 import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
 import com.assu.server.domain.inquiry.dto.InquiryAnswerRequestDTO;
+import com.assu.server.domain.inquiry.dto.InquiryResponseDTO;
 import com.assu.server.domain.inquiry.service.InquiryService;
 import com.assu.server.global.apiPayload.BaseResponse;
 import com.assu.server.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.inquiry.entity.Inquiry;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Backoffice", description = "백오피스 운영 API")
@@ -24,6 +30,56 @@ import org.springframework.web.bind.annotation.RestController;
 public class BackofficeInquiryController {
 
     private final InquiryService inquiryService;
+
+    @Operation(
+            summary = "운영자 전체 문의 목록 조회 API",
+            description = "# [v1.1 (2026-07-04)]\n" +
+                    "- 모든 사용자의 문의를 페이징으로 조회합니다.\n" +
+                    "- `status` 파라미터로 상태 필터링 가능합니다 (ALL / WAITING / ANSWERED).\n" +
+                    "- `keyword`가 있으면 제목 또는 본문에서 검색합니다.\n\n" +
+                    "**Query Parameters:**\n" +
+                    "- `status` (default: ALL): 문의 상태 필터\n" +
+                    "- `keyword` (optional): 제목 또는 본문 검색어\n" +
+                    "- `page` (default: 1): 페이지 번호\n" +
+                    "- `size` (default: 20): 페이지 크기\n\n" +
+                    "**Response:**\n" +
+                    "- 200(OK): 문의 목록 페이지 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증 실패 또는 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음"
+    )
+    @GetMapping
+    public BaseResponse<PageResponseDTO<InquiryResponseDTO>> listAllInquiries(
+            @Parameter(description = "상태 필터 (ALL / WAITING / ANSWERED)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") Inquiry.StatusFilter status,
+            @Parameter(description = "제목 또는 본문 검색어")
+            @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지 번호 (1 이상)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 크기 (1~200)", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, inquiryService.getAllInquiries(status, keyword, page, size));
+    }
+
+    @Operation(
+            summary = "운영자 문의 상세 조회 API",
+            description = "# [v1.0 (2026-06-25)]()\n" +
+                    "- 특정 문의의 상세 내용을 조회합니다.\n" +
+                    "- 소유권 검증 없이 모든 문의에 접근 가능합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `inquiryId` (Long, required): 문의 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 200(OK): 문의 상세 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증 실패 또는 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 문의 ID"
+    )
+    @GetMapping("/{inquiryId}")
+    public BaseResponse<InquiryResponseDTO> getInquiry(
+            @PathVariable("inquiryId") Long inquiryId
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, inquiryService.getById(inquiryId));
+    }
 
     @BackofficeAudited(action = "INQUIRY_ANSWER", targetId = "#inquiryId")
     @Operation(

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeInquiryController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeInquiryController.java
@@ -3,7 +3,7 @@ package com.assu.server.domain.backoffice.controller;
 import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
 import com.assu.server.domain.inquiry.dto.InquiryAnswerRequestDTO;
 import com.assu.server.domain.inquiry.dto.InquiryResponseDTO;
-import com.assu.server.domain.inquiry.service.InquiryService;
+import com.assu.server.domain.inquiry.service.BackofficeInquiryService;
 import com.assu.server.global.apiPayload.BaseResponse;
 import com.assu.server.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasRole('BACKOFFICE')")
 public class BackofficeInquiryController {
 
-    private final InquiryService inquiryService;
+    private final BackofficeInquiryService backofficeInquiryService;
 
     @Operation(
             summary = "운영자 전체 문의 목록 조회 API",
@@ -58,12 +58,12 @@ public class BackofficeInquiryController {
             @Parameter(description = "페이지 크기 (1~200)", example = "20")
             @RequestParam(defaultValue = "20") int size
     ) {
-        return BaseResponse.onSuccess(SuccessStatus._OK, inquiryService.getAllInquiries(status, keyword, page, size));
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeInquiryService.getInquiries(status, keyword, page, size));
     }
 
     @Operation(
             summary = "운영자 문의 상세 조회 API",
-            description = "# [v1.0 (2026-06-25)]()\n" +
+            description = "# [v1.0 (2026-06-25)]\n" +
                     "- 특정 문의의 상세 내용을 조회합니다.\n" +
                     "- 소유권 검증 없이 모든 문의에 접근 가능합니다.\n\n" +
                     "**Path Variable:**\n" +
@@ -78,7 +78,7 @@ public class BackofficeInquiryController {
     public BaseResponse<InquiryResponseDTO> getInquiry(
             @PathVariable("inquiryId") Long inquiryId
     ) {
-        return BaseResponse.onSuccess(SuccessStatus._OK, inquiryService.getById(inquiryId));
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeInquiryService.getById(inquiryId));
     }
 
     @BackofficeAudited(action = "INQUIRY_ANSWER", targetId = "#inquiryId")
@@ -100,11 +100,11 @@ public class BackofficeInquiryController {
                     "- 409(CONFLICT): 이미 답변된 문의"
     )
     @PatchMapping("/{inquiryId}/answer")
-    public BaseResponse<String> answer(
+    public BaseResponse<Void> answer(
             @PathVariable("inquiryId") Long inquiryId,
             @RequestBody @Valid InquiryAnswerRequestDTO inquiryAnswerRequestDTO
     ) {
-        inquiryService.answer(inquiryId, inquiryAnswerRequestDTO.answer());
-        return BaseResponse.onSuccess(SuccessStatus._OK, "The inquiry answered successfully. id=" + inquiryId);
+        backofficeInquiryService.answer(inquiryId, inquiryAnswerRequestDTO.answer());
+        return BaseResponse.onSuccess(SuccessStatus._OK, null);
     }
 }

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeNotificationController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeNotificationController.java
@@ -4,6 +4,7 @@ import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
 import com.assu.server.domain.backoffice.dto.BackofficeOutboxResponseDTO;
 import com.assu.server.domain.backoffice.dto.BackofficePushLogResponseDTO;
 import com.assu.server.domain.backoffice.dto.BackofficePushSendRequestDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeRetryOutboxResponseDTO;
 import com.assu.server.domain.backoffice.service.BackofficeNotificationService;
 import com.assu.server.domain.common.dto.PageResponseDTO;
 import com.assu.server.global.apiPayload.BaseResponse;
@@ -30,11 +31,11 @@ public class BackofficeNotificationController {
     @BackofficeAudited(action = "PUSH_SEND", targetId = "#request.receiverId()")
     @Operation(
             summary = "운영자 수동 푸시 알림 전송 API",
-            description = "# [v2.0 (2026-07-04)]\n" +
+            description = "# [v1.1 (2026-07-04)]\n" +
                     "- 그룹 또는 특정 사용자에게 자유 메시지 푸시 알림을 전송합니다.\n" +
                     "- `targetType`에 따라 수신자 범위가 결정됩니다.\n\n" +
                     "**Request Body:**\n" +
-                    "- `targetType` (required): ALL / STUDENT / UNION / PARTNER / INDIVIDUAL\n" +
+                    "- `targetType` (required): ALL / STUDENT / ADMIN / PARTNER / INDIVIDUAL\n" +
                     "- `receiverId` (INDIVIDUAL일 때만 필수): 수신자 멤버 ID\n" +
                     "- `title` (required): 푸시 제목\n" +
                     "- `body` (required): 푸시 본문\n" +
@@ -47,17 +48,17 @@ public class BackofficeNotificationController {
                     "- 404(NOT_FOUND): 존재하지 않는 수신자 멤버 ID"
     )
     @PostMapping("/push")
-    public BaseResponse<String> sendPush(
+    public BaseResponse<Void> sendPush(
             @RequestBody @Valid BackofficePushSendRequestDTO request,
             @AuthenticationPrincipal PrincipalDetails principal
     ) {
         backofficeNotificationService.sendPush(request, principal.getMemberId());
-        return BaseResponse.onSuccess(SuccessStatus._OK, "Push notifications sent successfully. targetType=" + request.targetType());
+        return BaseResponse.onSuccess(SuccessStatus._OK, null);
     }
 
     @Operation(
             summary = "푸시 발송 이력 조회 API",
-            description = "# [v2.0 (2026-07-04)]\n" +
+            description = "# [v1.1 (2026-07-04)]\n" +
                     "- 백오피스에서 발송한 푸시 알림 이력을 페이징으로 조회합니다.\n" +
                     "- `keyword`가 있으면 제목/본문에서 검색합니다.\n\n" +
                     "**Query Parameters:**\n" +
@@ -121,10 +122,10 @@ public class BackofficeNotificationController {
                     "- 404(NOT_FOUND): 존재하지 않는 Outbox ID"
     )
     @PostMapping("/outbox/{outboxId}/retry")
-    public BaseResponse<String> retryOutbox(
+    public BaseResponse<BackofficeRetryOutboxResponseDTO> retryOutbox(
             @PathVariable("outboxId") Long outboxId
     ) {
         backofficeNotificationService.retryOutbox(outboxId);
-        return BaseResponse.onSuccess(SuccessStatus._OK, "Outbox retry queued successfully. outboxId=" + outboxId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, BackofficeRetryOutboxResponseDTO.of(outboxId));
     }
 }

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeNotificationController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeNotificationController.java
@@ -1,0 +1,130 @@
+package com.assu.server.domain.backoffice.controller;
+
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.dto.BackofficeOutboxResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePushLogResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePushSendRequestDTO;
+import com.assu.server.domain.backoffice.service.BackofficeNotificationService;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+import com.assu.server.global.util.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/notifications")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficeNotificationController {
+
+    private final BackofficeNotificationService backofficeNotificationService;
+
+    @BackofficeAudited(action = "PUSH_SEND", targetId = "#request.receiverId()")
+    @Operation(
+            summary = "운영자 수동 푸시 알림 전송 API",
+            description = "# [v2.0 (2026-07-04)]\n" +
+                    "- 그룹 또는 특정 사용자에게 자유 메시지 푸시 알림을 전송합니다.\n" +
+                    "- `targetType`에 따라 수신자 범위가 결정됩니다.\n\n" +
+                    "**Request Body:**\n" +
+                    "- `targetType` (required): ALL / STUDENT / UNION / PARTNER / INDIVIDUAL\n" +
+                    "- `receiverId` (INDIVIDUAL일 때만 필수): 수신자 멤버 ID\n" +
+                    "- `title` (required): 푸시 제목\n" +
+                    "- `body` (required): 푸시 본문\n" +
+                    "- `deepLink` (optional): 딥링크 URL\n\n" +
+                    "**Response:**\n" +
+                    "- 200(OK): 발송 완료\n" +
+                    "- 400(BAD_REQUEST): 필수 파라미터 누락\n" +
+                    "- 401(UNAUTHORIZED): 인증 실패 또는 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 수신자 멤버 ID"
+    )
+    @PostMapping("/push")
+    public BaseResponse<String> sendPush(
+            @RequestBody @Valid BackofficePushSendRequestDTO request,
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        backofficeNotificationService.sendPush(request, principal.getMemberId());
+        return BaseResponse.onSuccess(SuccessStatus._OK, "Push notifications sent successfully. targetType=" + request.targetType());
+    }
+
+    @Operation(
+            summary = "푸시 발송 이력 조회 API",
+            description = "# [v2.0 (2026-07-04)]\n" +
+                    "- 백오피스에서 발송한 푸시 알림 이력을 페이징으로 조회합니다.\n" +
+                    "- `keyword`가 있으면 제목/본문에서 검색합니다.\n\n" +
+                    "**Query Parameters:**\n" +
+                    "- `keyword` (optional): 제목 또는 본문 검색어\n" +
+                    "- `page` (default: 1): 페이지 번호\n" +
+                    "- `size` (default: 20): 페이지 크기\n\n" +
+                    "**Response:**\n" +
+                    "- 200(OK): 푸시 이력 목록 페이지 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증 실패 또는 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음"
+    )
+    @GetMapping
+    public BaseResponse<PageResponseDTO<BackofficePushLogResponseDTO>> getPushLogs(
+            @Parameter(description = "제목 또는 본문 검색어")
+            @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지 번호 (1 이상)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 크기 (1~200)", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeNotificationService.getPushLogs(keyword, page, size));
+    }
+
+    @Operation(
+            summary = "전송 실패 알림 목록 조회 API",
+            description = "# [v1.0 (2026-06-25)]\n" +
+                    "- 전송 상태가 FAILED인 알림 Outbox 목록을 페이징으로 조회합니다.\n" +
+                    "- 자동 재시도 한도(3회)를 초과하여 실패 처리된 알림을 확인할 때 사용합니다.\n\n" +
+                    "**Query Parameters:**\n" +
+                    "- `page` (default: 1): 페이지 번호\n" +
+                    "- `size` (default: 20): 페이지 크기\n\n" +
+                    "**Response:**\n" +
+                    "- 200(OK): 실패 알림 목록 페이지 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증 실패 또는 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음"
+    )
+    @GetMapping("/outbox/failed")
+    public BaseResponse<PageResponseDTO<BackofficeOutboxResponseDTO>> getFailedOutboxes(
+            @Parameter(description = "페이지 번호 (1 이상)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 크기 (1~200)", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeNotificationService.getFailedOutboxes(page, size));
+    }
+
+    @BackofficeAudited(action = "PUSH_RETRY", targetId = "#outboxId")
+    @Operation(
+            summary = "실패 알림 수동 재전송 API",
+            description = "# [v1.0 (2026-06-25)]\n" +
+                    "- FAILED 상태의 특정 알림 Outbox를 수동으로 재전송합니다.\n" +
+                    "- 자동 재시도 횟수(retryCount)와 무관하게 재전송 가능합니다.\n" +
+                    "- 재전송 시 Outbox 상태가 PENDING으로 초기화되고 전송 파이프라인에 재등록됩니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `outboxId` (Long, required): 재전송할 Outbox ID\n\n" +
+                    "**Response:**\n" +
+                    "- 200(OK): 재전송 큐 등록 성공\n" +
+                    "- 400(BAD_REQUEST): FAILED 상태가 아닌 Outbox\n" +
+                    "- 401(UNAUTHORIZED): 인증 실패 또는 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 Outbox ID"
+    )
+    @PostMapping("/outbox/{outboxId}/retry")
+    public BaseResponse<String> retryOutbox(
+            @PathVariable("outboxId") Long outboxId
+    ) {
+        backofficeNotificationService.retryOutbox(outboxId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, "Outbox retry queued successfully. outboxId=" + outboxId);
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeOutboxResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeOutboxResponseDTO.java
@@ -1,0 +1,46 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.notification.entity.Notification;
+import com.assu.server.domain.notification.entity.NotificationOutbox;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BackofficeOutboxResponseDTO(
+
+        @Schema(description = "Outbox ID", example = "7")
+        Long outboxId,
+
+        @Schema(description = "알림 ID", example = "15")
+        Long notificationId,
+
+        @Schema(description = "수신자 멤버 ID", example = "42")
+        Long receiverId,
+
+        @Schema(description = "알림 타입", example = "STAMP")
+        String type,
+
+        @Schema(description = "알림 제목", example = "스탬프 10개 달성! 이벤트 응모 완료 🎁")
+        String title,
+
+        @Schema(description = "알림 미리보기 메시지", example = "스탬프 10개가 적립되어 기프티콘 증정 이벤트에 자동으로 응모되었어요.")
+        String messagePreview,
+
+        @Schema(description = "Outbox 상태 (PENDING / SENDING / DISPATCHED / SENT / FAILED)", example = "FAILED")
+        String status,
+
+        @Schema(description = "재시도 횟수", example = "3")
+        int retryCount
+) {
+    public static BackofficeOutboxResponseDTO from(NotificationOutbox outbox) {
+        Notification n = outbox.getNotification();
+        return new BackofficeOutboxResponseDTO(
+                outbox.getId(),
+                n.getId(),
+                n.getReceiver().getId(),
+                n.getType().name(),
+                n.getTitle(),
+                n.getMessagePreview(),
+                outbox.getStatus().name(),
+                outbox.getRetryCount()
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePushLogResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePushLogResponseDTO.java
@@ -1,0 +1,38 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.backoffice.entity.BackofficePushLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record BackofficePushLogResponseDTO(
+
+        @Schema(description = "로그 ID", example = "1")
+        Long logId,
+
+        @Schema(description = "발송 대상 유형", example = "ALL")
+        String targetType,
+
+        @Schema(description = "푸시 제목", example = "공지사항")
+        String title,
+
+        @Schema(description = "푸시 본문", example = "안녕하세요, 공지사항입니다.")
+        String body,
+
+        @Schema(description = "실제 발송된 수신자 수", example = "150")
+        int recipientCount,
+
+        @Schema(description = "발송 시각")
+        LocalDateTime sentAt
+) {
+    public static BackofficePushLogResponseDTO from(BackofficePushLog log) {
+        return new BackofficePushLogResponseDTO(
+                log.getId(),
+                log.getTargetType().name(),
+                log.getTitle(),
+                log.getBody(),
+                log.getRecipientCount(),
+                log.getSentAt()
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePushSendRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePushSendRequestDTO.java
@@ -1,0 +1,27 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.backoffice.entity.PushTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record BackofficePushSendRequestDTO(
+
+        @NotNull
+        @Schema(description = "발송 대상 유형 (ALL / STUDENT / UNION / PARTNER / INDIVIDUAL)", example = "ALL")
+        PushTargetType targetType,
+
+        @Schema(description = "수신자 멤버 ID (targetType=INDIVIDUAL일 때만 필수)", example = "42")
+        Long receiverId,
+
+        @NotBlank
+        @Schema(description = "푸시 제목", example = "공지사항")
+        String title,
+
+        @NotBlank
+        @Schema(description = "푸시 본문", example = "안녕하세요, 공지사항입니다.")
+        String body,
+
+        @Schema(description = "딥링크 URL (선택)", example = "/notice/1")
+        String deepLink
+) {}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePushSendRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePushSendRequestDTO.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull;
 public record BackofficePushSendRequestDTO(
 
         @NotNull
-        @Schema(description = "발송 대상 유형 (ALL / STUDENT / UNION / PARTNER / INDIVIDUAL)", example = "ALL")
+        @Schema(description = "발송 대상 유형 (ALL / STUDENT / ADMIN / PARTNER / INDIVIDUAL)", example = "ALL")
         PushTargetType targetType,
 
         @Schema(description = "수신자 멤버 ID (targetType=INDIVIDUAL일 때만 필수)", example = "42")

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeRetryOutboxResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeRetryOutboxResponseDTO.java
@@ -1,0 +1,13 @@
+package com.assu.server.domain.backoffice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BackofficeRetryOutboxResponseDTO(
+
+        @Schema(description = "재전송 큐에 등록된 Outbox ID", example = "7")
+        Long outboxId
+) {
+    public static BackofficeRetryOutboxResponseDTO of(Long outboxId) {
+        return new BackofficeRetryOutboxResponseDTO(outboxId);
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/entity/BackofficePushLog.java
+++ b/src/main/java/com/assu/server/domain/backoffice/entity/BackofficePushLog.java
@@ -1,0 +1,41 @@
+package com.assu.server.domain.backoffice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BackofficePushLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PushTargetType targetType;
+
+    private Long receiverId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    private String deepLink;
+
+    @Column(nullable = false)
+    private Long sentByMemberId;
+
+    @Column(nullable = false)
+    private int recipientCount;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+}

--- a/src/main/java/com/assu/server/domain/backoffice/entity/PushTargetType.java
+++ b/src/main/java/com/assu/server/domain/backoffice/entity/PushTargetType.java
@@ -1,0 +1,5 @@
+package com.assu.server.domain.backoffice.entity;
+
+public enum PushTargetType {
+    ALL, STUDENT, UNION, PARTNER, INDIVIDUAL
+}

--- a/src/main/java/com/assu/server/domain/backoffice/entity/PushTargetType.java
+++ b/src/main/java/com/assu/server/domain/backoffice/entity/PushTargetType.java
@@ -1,5 +1,5 @@
 package com.assu.server.domain.backoffice.entity;
 
 public enum PushTargetType {
-    ALL, STUDENT, UNION, PARTNER, INDIVIDUAL
+    ALL, STUDENT, ADMIN, PARTNER, INDIVIDUAL
 }

--- a/src/main/java/com/assu/server/domain/backoffice/repository/BackofficePushLogRepository.java
+++ b/src/main/java/com/assu/server/domain/backoffice/repository/BackofficePushLogRepository.java
@@ -1,0 +1,13 @@
+package com.assu.server.domain.backoffice.repository;
+
+import com.assu.server.domain.backoffice.entity.BackofficePushLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BackofficePushLogRepository extends JpaRepository<BackofficePushLog, Long> {
+
+    Page<BackofficePushLog> findByTitleContainingOrBodyContaining(
+            String title, String body, Pageable pageable
+    );
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationService.java
@@ -1,0 +1,21 @@
+package com.assu.server.domain.backoffice.service;
+
+import com.assu.server.domain.backoffice.dto.BackofficeOutboxResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePushLogResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePushSendRequestDTO;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+
+public interface BackofficeNotificationService {
+
+    /** 그룹/개인 자유 메시지 푸시 발송 */
+    void sendPush(BackofficePushSendRequestDTO request, Long sentByMemberId);
+
+    /** 푸시 발송 이력 목록 조회 */
+    PageResponseDTO<BackofficePushLogResponseDTO> getPushLogs(String keyword, int page, int size);
+
+    /** 전송 실패(FAILED) 알림 목록 페이징 조회 */
+    PageResponseDTO<BackofficeOutboxResponseDTO> getFailedOutboxes(int page, int size);
+
+    /** 특정 실패 알림 수동 재전송 */
+    void retryOutbox(Long outboxId);
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationService.java
@@ -7,15 +7,11 @@ import com.assu.server.domain.common.dto.PageResponseDTO;
 
 public interface BackofficeNotificationService {
 
-    /** 그룹/개인 자유 메시지 푸시 발송 */
     void sendPush(BackofficePushSendRequestDTO request, Long sentByMemberId);
 
-    /** 푸시 발송 이력 목록 조회 */
     PageResponseDTO<BackofficePushLogResponseDTO> getPushLogs(String keyword, int page, int size);
 
-    /** 전송 실패(FAILED) 알림 목록 페이징 조회 */
     PageResponseDTO<BackofficeOutboxResponseDTO> getFailedOutboxes(int page, int size);
 
-    /** 특정 실패 알림 수동 재전송 */
     void retryOutbox(Long outboxId);
 }

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationServiceImpl.java
@@ -8,15 +8,15 @@ import com.assu.server.domain.backoffice.entity.PushTargetType;
 import com.assu.server.domain.backoffice.repository.BackofficePushLogRepository;
 import com.assu.server.domain.common.dto.PageResponseDTO;
 import com.assu.server.domain.common.enums.UserRole;
-import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.member.repository.MemberRepository;
-import com.assu.server.domain.notification.entity.Notification;
 import com.assu.server.domain.notification.entity.NotificationOutbox;
 import com.assu.server.domain.notification.entity.OutboxCreatedEvent;
+import com.assu.server.domain.notification.entity.Notification;
 import com.assu.server.domain.notification.repository.NotificationOutboxRepository;
-import com.assu.server.domain.notification.service.NotificationCommandService;
+import com.assu.server.domain.notification.service.NotificationBackofficeService;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
 import com.assu.server.global.exception.DatabaseException;
+import com.assu.server.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -34,7 +34,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BackofficeNotificationServiceImpl implements BackofficeNotificationService {
 
-    private final NotificationCommandService notificationCommandService;
+    private final NotificationBackofficeService notificationBackofficeService;
     private final NotificationOutboxRepository outboxRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final MemberRepository memberRepository;
@@ -42,11 +42,11 @@ public class BackofficeNotificationServiceImpl implements BackofficeNotification
 
     @Override
     public void sendPush(BackofficePushSendRequestDTO request, Long sentByMemberId) {
-        List<Member> recipients = resolveRecipients(request);
+        List<Long> recipientIds = resolveRecipientIds(request);
 
-        for (Member recipient : recipients) {
-            notificationCommandService.createAndQueue(
-                    recipient.getId(),
+        for (Long id : recipientIds) {
+            notificationBackofficeService.createAndQueue(
+                    id,
                     request.title(),
                     request.body(),
                     request.deepLink()
@@ -60,33 +60,33 @@ public class BackofficeNotificationServiceImpl implements BackofficeNotification
                 .body(request.body())
                 .deepLink(request.deepLink())
                 .sentByMemberId(sentByMemberId)
-                .recipientCount(recipients.size())
+                .recipientCount(recipientIds.size())
                 .sentAt(LocalDateTime.now())
                 .build());
     }
 
-    private List<Member> resolveRecipients(BackofficePushSendRequestDTO request) {
+    private List<Long> resolveRecipientIds(BackofficePushSendRequestDTO request) {
         return switch (request.targetType()) {
             case INDIVIDUAL -> {
                 if (request.receiverId() == null) {
-                    throw new DatabaseException(ErrorStatus.NO_SUCH_MEMBER);
+                    throw new GeneralException(ErrorStatus.RECEIVER_ID_REQUIRED);
                 }
-                Member member = memberRepository.findMemberById(request.receiverId())
+                memberRepository.findMemberById(request.receiverId())
                         .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_MEMBER));
-                yield List.of(member);
+                yield List.of(request.receiverId());
             }
-            case ALL -> memberRepository.findAll();
-            case STUDENT -> memberRepository.findByRole(UserRole.STUDENT);
-            case UNION -> memberRepository.findByRole(UserRole.ADMIN);
-            case PARTNER -> memberRepository.findByRole(UserRole.PARTNER);
+            case ALL -> memberRepository.findAllIds();
+            case STUDENT -> memberRepository.findIdsByRole(UserRole.STUDENT);
+            case ADMIN -> memberRepository.findIdsByRole(UserRole.ADMIN);
+            case PARTNER -> memberRepository.findIdsByRole(UserRole.PARTNER);
         };
     }
 
     @Override
     @Transactional(readOnly = true)
     public PageResponseDTO<BackofficePushLogResponseDTO> getPushLogs(String keyword, int page, int size) {
-        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
-        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
+        if (page < 1) throw new GeneralException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new GeneralException(ErrorStatus.PAGE_SIZE_INVALID);
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<BackofficePushLogResponseDTO> result;
@@ -103,8 +103,8 @@ public class BackofficeNotificationServiceImpl implements BackofficeNotification
     @Override
     @Transactional(readOnly = true)
     public PageResponseDTO<BackofficeOutboxResponseDTO> getFailedOutboxes(int page, int size) {
-        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
-        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
+        if (page < 1) throw new GeneralException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new GeneralException(ErrorStatus.PAGE_SIZE_INVALID);
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<BackofficeOutboxResponseDTO> result = outboxRepository

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeNotificationServiceImpl.java
@@ -1,0 +1,139 @@
+package com.assu.server.domain.backoffice.service;
+
+import com.assu.server.domain.backoffice.dto.BackofficeOutboxResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePushLogResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficePushSendRequestDTO;
+import com.assu.server.domain.backoffice.entity.BackofficePushLog;
+import com.assu.server.domain.backoffice.entity.PushTargetType;
+import com.assu.server.domain.backoffice.repository.BackofficePushLogRepository;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.member.repository.MemberRepository;
+import com.assu.server.domain.notification.entity.Notification;
+import com.assu.server.domain.notification.entity.NotificationOutbox;
+import com.assu.server.domain.notification.entity.OutboxCreatedEvent;
+import com.assu.server.domain.notification.repository.NotificationOutboxRepository;
+import com.assu.server.domain.notification.service.NotificationCommandService;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import com.assu.server.global.exception.DatabaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BackofficeNotificationServiceImpl implements BackofficeNotificationService {
+
+    private final NotificationCommandService notificationCommandService;
+    private final NotificationOutboxRepository outboxRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MemberRepository memberRepository;
+    private final BackofficePushLogRepository pushLogRepository;
+
+    @Override
+    public void sendPush(BackofficePushSendRequestDTO request, Long sentByMemberId) {
+        List<Member> recipients = resolveRecipients(request);
+
+        for (Member recipient : recipients) {
+            notificationCommandService.createAndQueue(
+                    recipient.getId(),
+                    request.title(),
+                    request.body(),
+                    request.deepLink()
+            );
+        }
+
+        pushLogRepository.save(BackofficePushLog.builder()
+                .targetType(request.targetType())
+                .receiverId(request.targetType() == PushTargetType.INDIVIDUAL ? request.receiverId() : null)
+                .title(request.title())
+                .body(request.body())
+                .deepLink(request.deepLink())
+                .sentByMemberId(sentByMemberId)
+                .recipientCount(recipients.size())
+                .sentAt(LocalDateTime.now())
+                .build());
+    }
+
+    private List<Member> resolveRecipients(BackofficePushSendRequestDTO request) {
+        return switch (request.targetType()) {
+            case INDIVIDUAL -> {
+                if (request.receiverId() == null) {
+                    throw new DatabaseException(ErrorStatus.NO_SUCH_MEMBER);
+                }
+                Member member = memberRepository.findMemberById(request.receiverId())
+                        .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_MEMBER));
+                yield List.of(member);
+            }
+            case ALL -> memberRepository.findAll();
+            case STUDENT -> memberRepository.findByRole(UserRole.STUDENT);
+            case UNION -> memberRepository.findByRole(UserRole.ADMIN);
+            case PARTNER -> memberRepository.findByRole(UserRole.PARTNER);
+        };
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<BackofficePushLogResponseDTO> getPushLogs(String keyword, int page, int size) {
+        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<BackofficePushLogResponseDTO> result;
+        if (keyword != null && !keyword.isBlank()) {
+            result = pushLogRepository
+                    .findByTitleContainingOrBodyContaining(keyword, keyword, pageable)
+                    .map(BackofficePushLogResponseDTO::from);
+        } else {
+            result = pushLogRepository.findAll(pageable).map(BackofficePushLogResponseDTO::from);
+        }
+        return PageResponseDTO.of(result);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<BackofficeOutboxResponseDTO> getFailedOutboxes(int page, int size) {
+        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<BackofficeOutboxResponseDTO> result = outboxRepository
+                .findByStatus(NotificationOutbox.Status.FAILED, pageable)
+                .map(BackofficeOutboxResponseDTO::from);
+        return PageResponseDTO.of(result);
+    }
+
+    @Override
+    public void retryOutbox(Long outboxId) {
+        NotificationOutbox outbox = outboxRepository.findById(outboxId)
+                .orElseThrow(() -> new DatabaseException(ErrorStatus.OUTBOX_NOT_FOUND));
+
+        if (outbox.getStatus() != NotificationOutbox.Status.FAILED) {
+            throw new DatabaseException(ErrorStatus.OUTBOX_NOT_FAILED);
+        }
+
+        outboxRepository.resetToPendingById(outboxId);
+
+        Notification n = outbox.getNotification();
+        eventPublisher.publishEvent(new OutboxCreatedEvent(
+                outbox.getId(),
+                n.getReceiver().getId(),
+                n.getTitle(),
+                n.getMessagePreview(),
+                n.getType().name(),
+                n.getRefId(),
+                n.getDeeplink(),
+                n.getId()
+        ));
+    }
+}

--- a/src/main/java/com/assu/server/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/assu/server/domain/inquiry/repository/InquiryRepository.java
@@ -8,4 +8,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
     Page<Inquiry> findByMemberId(Long memberId, Pageable pageable);
     Page<Inquiry> findByMemberIdAndStatus(Long memberId, Status status, Pageable pageable);
+    Page<Inquiry> findByStatus(Status status, Pageable pageable);
+
+    Page<Inquiry> findByStatusAndTitleContainingOrStatusAndContentContaining(
+            Status status1, String title,
+            Status status2, String content,
+            Pageable pageable
+    );
+
+    Page<Inquiry> findByTitleContainingOrContentContaining(
+            String title, String content, Pageable pageable
+    );
 }

--- a/src/main/java/com/assu/server/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/assu/server/domain/inquiry/repository/InquiryRepository.java
@@ -4,19 +4,17 @@ import com.assu.server.domain.inquiry.entity.Inquiry;
 import com.assu.server.domain.inquiry.entity.Inquiry.Status;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
     Page<Inquiry> findByMemberId(Long memberId, Pageable pageable);
     Page<Inquiry> findByMemberIdAndStatus(Long memberId, Status status, Pageable pageable);
     Page<Inquiry> findByStatus(Status status, Pageable pageable);
 
-    Page<Inquiry> findByStatusAndTitleContainingOrStatusAndContentContaining(
-            Status status1, String title,
-            Status status2, String content,
-            Pageable pageable
-    );
+    @Query("SELECT i FROM Inquiry i WHERE i.status = :status AND (i.title LIKE %:keyword% OR i.content LIKE %:keyword%)")
+    Page<Inquiry> findByStatusAndKeyword(@Param("status") Status status, @Param("keyword") String keyword, Pageable pageable);
 
-    Page<Inquiry> findByTitleContainingOrContentContaining(
-            String title, String content, Pageable pageable
-    );
+    @Query("SELECT i FROM Inquiry i WHERE i.title LIKE %:keyword% OR i.content LIKE %:keyword%")
+    Page<Inquiry> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/assu/server/domain/inquiry/service/BackofficeInquiryService.java
+++ b/src/main/java/com/assu/server/domain/inquiry/service/BackofficeInquiryService.java
@@ -1,0 +1,11 @@
+package com.assu.server.domain.inquiry.service;
+
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.inquiry.dto.InquiryResponseDTO;
+import com.assu.server.domain.inquiry.entity.Inquiry;
+
+public interface BackofficeInquiryService {
+    PageResponseDTO<InquiryResponseDTO> getInquiries(Inquiry.StatusFilter status, String keyword, int page, int size);
+    InquiryResponseDTO getById(Long inquiryId);
+    void answer(Long inquiryId, String answerText);
+}

--- a/src/main/java/com/assu/server/domain/inquiry/service/BackofficeInquiryServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/inquiry/service/BackofficeInquiryServiceImpl.java
@@ -1,0 +1,71 @@
+package com.assu.server.domain.inquiry.service;
+
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.inquiry.dto.InquiryResponseDTO;
+import com.assu.server.domain.inquiry.entity.Inquiry;
+import com.assu.server.domain.inquiry.entity.Inquiry.Status;
+import com.assu.server.domain.inquiry.repository.InquiryRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import com.assu.server.global.exception.DatabaseException;
+import com.assu.server.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BackofficeInquiryServiceImpl implements BackofficeInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<InquiryResponseDTO> getInquiries(Inquiry.StatusFilter status, String keyword, int page, int size) {
+        if (page < 1) throw new GeneralException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new GeneralException(ErrorStatus.PAGE_SIZE_INVALID);
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+
+        Page<Inquiry> result;
+        if (hasKeyword) {
+            result = switch (status) {
+                case WAITING -> inquiryRepository.findByStatusAndKeyword(Status.WAITING, keyword, pageable);
+                case ANSWERED -> inquiryRepository.findByStatusAndKeyword(Status.ANSWERED, keyword, pageable);
+                case ALL -> inquiryRepository.findByKeyword(keyword, pageable);
+            };
+        } else {
+            result = switch (status) {
+                case WAITING -> inquiryRepository.findByStatus(Status.WAITING, pageable);
+                case ANSWERED -> inquiryRepository.findByStatus(Status.ANSWERED, pageable);
+                case ALL -> inquiryRepository.findAll(pageable);
+            };
+        }
+        return PageResponseDTO.of(result.map(InquiryResponseDTO::from));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public InquiryResponseDTO getById(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_INQUIRY));
+        return InquiryResponseDTO.from(inquiry);
+    }
+
+    @Override
+    public void answer(Long inquiryId, String answerText) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_INQUIRY));
+
+        if (inquiry.getStatus() == Inquiry.Status.ANSWERED) {
+            throw new DatabaseException(ErrorStatus.ALREADY_ANSWERED);
+        }
+
+        inquiry.answer(answerText);
+    }
+}

--- a/src/main/java/com/assu/server/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/assu/server/domain/inquiry/service/InquiryService.java
@@ -13,4 +13,8 @@ public interface InquiryService {
     InquiryResponseDTO get(Long inquiryId, Long memberId);
     void answer(Long inquiryId, String answerText);
     Page<InquiryResponseDTO> list(Inquiry.StatusFilter status, Pageable pageable, Long memberId);
+
+    // 백오피스 전용 (소유권 검증 없음)
+    PageResponseDTO<InquiryResponseDTO> getAllInquiries(Inquiry.StatusFilter status, String keyword, int page, int size);
+    InquiryResponseDTO getById(Long inquiryId);
 }

--- a/src/main/java/com/assu/server/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/assu/server/domain/inquiry/service/InquiryService.java
@@ -11,10 +11,5 @@ public interface InquiryService {
     Long create(InquiryCreateRequestDTO inquiryCreateRequestDTO, Long memberId);
     PageResponseDTO<InquiryResponseDTO> getInquiries(Inquiry.StatusFilter status, int page, int size, Long memberId);
     InquiryResponseDTO get(Long inquiryId, Long memberId);
-    void answer(Long inquiryId, String answerText);
     Page<InquiryResponseDTO> list(Inquiry.StatusFilter status, Pageable pageable, Long memberId);
-
-    // 백오피스 전용 (소유권 검증 없음)
-    PageResponseDTO<InquiryResponseDTO> getAllInquiries(Inquiry.StatusFilter status, String keyword, int page, int size);
-    InquiryResponseDTO getById(Long inquiryId);
 }

--- a/src/main/java/com/assu/server/domain/inquiry/service/InquiryServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/inquiry/service/InquiryServiceImpl.java
@@ -10,6 +10,7 @@ import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.member.repository.MemberRepository;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
 import com.assu.server.global.exception.DatabaseException;
+import com.assu.server.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
@@ -39,8 +40,8 @@ public class InquiryServiceImpl implements InquiryService {
     @Override
     @Transactional(readOnly = true)
     public PageResponseDTO<InquiryResponseDTO> getInquiries(Inquiry.StatusFilter status, int page, int size, Long memberId) {
-        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
-        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
+        if (page < 1) throw new GeneralException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new GeneralException(ErrorStatus.PAGE_SIZE_INVALID);
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<InquiryResponseDTO> result = list(status, pageable, memberId);
@@ -72,54 +73,4 @@ public class InquiryServiceImpl implements InquiryService {
         return InquiryResponseDTO.from(inquiry);
     }
 
-    /** 백오피스 전체 문의 목록 조회 (소유권 검증 없음, keyword 검색 지원) */
-    @Override
-    @Transactional(readOnly = true)
-    public PageResponseDTO<InquiryResponseDTO> getAllInquiries(Inquiry.StatusFilter status, String keyword, int page, int size) {
-        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
-        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
-
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
-        boolean hasKeyword = keyword != null && !keyword.isBlank();
-
-        Page<Inquiry> result;
-        if (hasKeyword) {
-            result = switch (status) {
-                case WAITING -> inquiryRepository.findByStatusAndTitleContainingOrStatusAndContentContaining(
-                        Status.WAITING, keyword, Status.WAITING, keyword, pageable);
-                case ANSWERED -> inquiryRepository.findByStatusAndTitleContainingOrStatusAndContentContaining(
-                        Status.ANSWERED, keyword, Status.ANSWERED, keyword, pageable);
-                case ALL -> inquiryRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
-            };
-        } else {
-            result = switch (status) {
-                case WAITING -> inquiryRepository.findByStatus(Status.WAITING, pageable);
-                case ANSWERED -> inquiryRepository.findByStatus(Status.ANSWERED, pageable);
-                case ALL -> inquiryRepository.findAll(pageable);
-            };
-        }
-        return PageResponseDTO.of(result.map(InquiryResponseDTO::from));
-    }
-
-    /** 백오피스 단건 조회 (소유권 검증 없음) */
-    @Override
-    @Transactional(readOnly = true)
-    public InquiryResponseDTO getById(Long inquiryId) {
-        Inquiry inquiry = inquiryRepository.findById(inquiryId)
-                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_INQUIRY));
-        return InquiryResponseDTO.from(inquiry);
-    }
-
-    /** 답변 저장(상태 ANSWERED 전환) */
-    @Override
-    public void answer(Long inquiryId, String answerText) {
-        Inquiry inquiry = inquiryRepository.findById(inquiryId)
-                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_INQUIRY));
-
-        if (inquiry.getStatus() == Inquiry.Status.ANSWERED) {
-            throw new DatabaseException(ErrorStatus.ALREADY_ANSWERED);
-        }
-
-        inquiry.answer(answerText);
-    }
 }

--- a/src/main/java/com/assu/server/domain/inquiry/service/InquiryServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/inquiry/service/InquiryServiceImpl.java
@@ -72,6 +72,44 @@ public class InquiryServiceImpl implements InquiryService {
         return InquiryResponseDTO.from(inquiry);
     }
 
+    /** 백오피스 전체 문의 목록 조회 (소유권 검증 없음, keyword 검색 지원) */
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<InquiryResponseDTO> getAllInquiries(Inquiry.StatusFilter status, String keyword, int page, int size) {
+        if (page < 1) throw new DatabaseException(ErrorStatus.PAGE_UNDER_ONE);
+        if (size < 1 || size > 200) throw new DatabaseException(ErrorStatus.PAGE_SIZE_INVALID);
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+
+        Page<Inquiry> result;
+        if (hasKeyword) {
+            result = switch (status) {
+                case WAITING -> inquiryRepository.findByStatusAndTitleContainingOrStatusAndContentContaining(
+                        Status.WAITING, keyword, Status.WAITING, keyword, pageable);
+                case ANSWERED -> inquiryRepository.findByStatusAndTitleContainingOrStatusAndContentContaining(
+                        Status.ANSWERED, keyword, Status.ANSWERED, keyword, pageable);
+                case ALL -> inquiryRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
+            };
+        } else {
+            result = switch (status) {
+                case WAITING -> inquiryRepository.findByStatus(Status.WAITING, pageable);
+                case ANSWERED -> inquiryRepository.findByStatus(Status.ANSWERED, pageable);
+                case ALL -> inquiryRepository.findAll(pageable);
+            };
+        }
+        return PageResponseDTO.of(result.map(InquiryResponseDTO::from));
+    }
+
+    /** 백오피스 단건 조회 (소유권 검증 없음) */
+    @Override
+    @Transactional(readOnly = true)
+    public InquiryResponseDTO getById(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_INQUIRY));
+        return InquiryResponseDTO.from(inquiry);
+    }
+
     /** 답변 저장(상태 ANSWERED 전환) */
     @Override
     public void answer(Long inquiryId, String answerText) {

--- a/src/main/java/com/assu/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/assu/server/domain/member/repository/MemberRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +16,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberById(Long id);
     List<Member> findByDeletedAtBefore(LocalDateTime deletedAt);
     List<Member> findByRole(UserRole role);
+
+    @Query("SELECT m.id FROM Member m")
+    List<Long> findAllIds();
+
+    @Query("SELECT m.id FROM Member m WHERE m.role = :role")
+    List<Long> findIdsByRole(@Param("role") UserRole role);
 }

--- a/src/main/java/com/assu/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/assu/server/domain/member/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,4 +13,5 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberById(Long id);
     List<Member> findByDeletedAtBefore(LocalDateTime deletedAt);
+    List<Member> findByRole(UserRole role);
 }

--- a/src/main/java/com/assu/server/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/assu/server/domain/notification/entity/NotificationType.java
@@ -9,7 +9,8 @@ public enum NotificationType {
     ORDER("order"),
     PARTNER_ALL("partner_all"), // 채팅, 주문 안내
     ADMIN_ALL("admin_all"), // 채팅, 제휴 건의, 제휴 제안
-    STAMP("stamp");
+    STAMP("stamp"),
+    BACKOFFICE("backoffice");
 
     private final String code;
     NotificationType(String code) { this.code = code; }

--- a/src/main/java/com/assu/server/domain/notification/repository/NotificationOutboxRepository.java
+++ b/src/main/java/com/assu/server/domain/notification/repository/NotificationOutboxRepository.java
@@ -2,6 +2,8 @@ package com.assu.server.domain.notification.repository;
 
 import com.assu.server.domain.notification.entity.NotificationOutbox;
 import com.assu.server.domain.notification.entity.NotificationOutbox.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -40,4 +42,15 @@ public interface NotificationOutboxRepository extends JpaRepository<Notification
     boolean existsByIdAndStatus(Long id, NotificationOutbox.Status status);
 
     List<NotificationOutbox> findByStatusAndRetryCountLessThan(NotificationOutbox.Status status, int maxRetryCount);
+
+    Page<NotificationOutbox> findByStatus(NotificationOutbox.Status status, Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE NotificationOutbox o
+           SET o.status = :#{T(com.assu.server.domain.notification.entity.NotificationOutbox$Status).PENDING}
+         WHERE o.id = :id
+           AND o.status = :#{T(com.assu.server.domain.notification.entity.NotificationOutbox$Status).FAILED}
+        """)
+    int resetToPendingById(@Param("id") Long id);
 }

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationBackofficeService.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationBackofficeService.java
@@ -1,0 +1,5 @@
+package com.assu.server.domain.notification.service;
+
+public interface NotificationBackofficeService {
+    void createAndQueue(Long receiverId, String title, String body, String deepLink);
+}

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationBackofficeServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationBackofficeServiceImpl.java
@@ -1,0 +1,59 @@
+package com.assu.server.domain.notification.service;
+
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.member.repository.MemberRepository;
+import com.assu.server.domain.notification.entity.*;
+import com.assu.server.domain.notification.repository.NotificationOutboxRepository;
+import com.assu.server.domain.notification.repository.NotificationRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import com.assu.server.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationBackofficeServiceImpl implements NotificationBackofficeService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationOutboxRepository outboxRepository;
+    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createAndQueue(Long receiverId, String title, String body, String deepLink) {
+        Member member = memberRepository.findMemberById(receiverId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));
+
+        Notification notification = Notification.builder()
+                .receiver(member)
+                .type(NotificationType.BACKOFFICE)
+                .refId(null)
+                .title(title)
+                .messagePreview(body)
+                .deeplink(deepLink != null ? deepLink : "/backoffice")
+                .build();
+        notificationRepository.save(notification);
+
+        NotificationOutbox outbox = NotificationOutbox.builder()
+                .notification(notification)
+                .status(NotificationOutbox.Status.PENDING)
+                .retryCount(0)
+                .build();
+        outboxRepository.save(outbox);
+
+        eventPublisher.publishEvent(new OutboxCreatedEvent(
+                outbox.getId(),
+                member.getId(),
+                notification.getTitle(),
+                notification.getMessagePreview(),
+                NotificationType.BACKOFFICE.name(),
+                null,
+                notification.getDeeplink(),
+                notification.getId()
+        ));
+    }
+}

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationCommandService.java
@@ -10,8 +10,6 @@ import java.util.Map;
 public interface NotificationCommandService {
     Notification createAndQueue(Long receiverId, NotificationType type, Long refId, Map<String, Object> ctx);
 
-    /** 자유 메시지 직접 지정하는 푸시 (백오피스 수동 발송용) */
-    void createAndQueue(Long receiverId, String title, String body, String deepLink);
     void markRead(Long notificationId, Long currentMemberId) throws AccessDeniedException;
     void queue(QueueNotificationRequestDTO req);
     Map<String, Boolean> toggle(Long memberId, NotificationType type);

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationCommandService.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 public interface NotificationCommandService {
     Notification createAndQueue(Long receiverId, NotificationType type, Long refId, Map<String, Object> ctx);
+
+    /** 자유 메시지 직접 지정하는 푸시 (백오피스 수동 발송용) */
+    void createAndQueue(Long receiverId, String title, String body, String deepLink);
     void markRead(Long notificationId, Long currentMemberId) throws AccessDeniedException;
     void queue(QueueNotificationRequestDTO req);
     Map<String, Boolean> toggle(Long memberId, NotificationType type);

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationCommandServiceImpl.java
@@ -29,40 +29,6 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
     private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @Override
-    public void createAndQueue(Long receiverId, String title, String body, String deepLink) {
-        Member member = memberRepository.findMemberById(receiverId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));
-
-        Notification notification = Notification.builder()
-                .receiver(member)
-                .type(NotificationType.BACKOFFICE)
-                .refId(null)
-                .title(title)
-                .messagePreview(body)
-                .deeplink(deepLink != null ? deepLink : "/backoffice")
-                .build();
-        notificationRepository.save(notification);
-
-        NotificationOutbox outbox = NotificationOutbox.builder()
-                .notification(notification)
-                .status(NotificationOutbox.Status.PENDING)
-                .retryCount(0)
-                .build();
-        outboxRepository.save(outbox);
-
-        eventPublisher.publishEvent(new OutboxCreatedEvent(
-                outbox.getId(),
-                member.getId(),
-                notification.getTitle(),
-                notification.getMessagePreview(),
-                NotificationType.BACKOFFICE.name(),
-                null,
-                notification.getDeeplink(),
-                notification.getId()
-        ));
-    }
-
-    @Override
     public Notification createAndQueue(Long receiverId, NotificationType type, Long refId, Map<String, Object> ctx) {
         Member member = memberRepository.findMemberById(receiverId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));

--- a/src/main/java/com/assu/server/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationCommandServiceImpl.java
@@ -29,6 +29,40 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
     private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @Override
+    public void createAndQueue(Long receiverId, String title, String body, String deepLink) {
+        Member member = memberRepository.findMemberById(receiverId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));
+
+        Notification notification = Notification.builder()
+                .receiver(member)
+                .type(NotificationType.BACKOFFICE)
+                .refId(null)
+                .title(title)
+                .messagePreview(body)
+                .deeplink(deepLink != null ? deepLink : "/backoffice")
+                .build();
+        notificationRepository.save(notification);
+
+        NotificationOutbox outbox = NotificationOutbox.builder()
+                .notification(notification)
+                .status(NotificationOutbox.Status.PENDING)
+                .retryCount(0)
+                .build();
+        outboxRepository.save(outbox);
+
+        eventPublisher.publishEvent(new OutboxCreatedEvent(
+                outbox.getId(),
+                member.getId(),
+                notification.getTitle(),
+                notification.getMessagePreview(),
+                NotificationType.BACKOFFICE.name(),
+                null,
+                notification.getDeeplink(),
+                notification.getId()
+        ));
+    }
+
+    @Override
     public Notification createAndQueue(Long receiverId, NotificationType type, Long refId, Map<String, Object> ctx) {
         Member member = memberRepository.findMemberById(receiverId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));

--- a/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
@@ -88,6 +88,8 @@ public enum ErrorStatus implements BaseErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND,"NOTIFICATION_4003","존재하지 않는 알림입니다."),
     NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN,"NOTIFICATION_4004","해당 알림에 접근할 권한이 없습니다."),
     MISSING_NOTIFICATION_FIELD(HttpStatus.BAD_REQUEST,"NOTIFICATION_4005","알림 생성에 필요한 필드가 누락되었습니다."),
+    OUTBOX_NOT_FOUND(HttpStatus.NOT_FOUND,"NOTIFICATION_4006","존재하지 않는 알림 Outbox입니다."),
+    OUTBOX_NOT_FAILED(HttpStatus.BAD_REQUEST,"NOTIFICATION_4007","FAILED 상태인 Outbox만 수동 재전송할 수 있습니다."),
 
     // 문의(Inquiry)
     INVALID_INQUIRY_STATUS_FILTER(HttpStatus.BAD_REQUEST,"INQUIRY_4001","status는 [all, waiting, answered] 중 하나여야 합니다."),

--- a/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
@@ -49,6 +49,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BACKOFFICE_BOOTSTRAP_DISABLED(HttpStatus.BAD_REQUEST, "BACKOFFICE4001", "백오피스 bootstrap이 비활성화되어 있습니다."),
     LAST_BACKOFFICE_OPERATOR(HttpStatus.BAD_REQUEST, "BACKOFFICE4002", "마지막 백오피스 운영자는 비활성화할 수 없습니다."),
     BACKOFFICE_USE_DEDICATED_LOGIN(HttpStatus.FORBIDDEN, "BACKOFFICE4003", "백오피스 계정은 /auth/backoffice/login을 사용해야 합니다."),
+    RECEIVER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "PUSH_4001", "INDIVIDUAL 타입일 경우 receiverId는 필수입니다."),
 
     NO_SUCH_ADMIN(HttpStatus.NOT_FOUND,"MEMBER_4002","존재하지 않는 admin ID 입니다."),
     NO_SUCH_PARTNER(HttpStatus.NOT_FOUND,"MEMBER_4003","존재하지 않는 partner ID 입니다."),

--- a/src/main/java/com/assu/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/assu/server/global/config/WebSocketConfig.java
@@ -24,7 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")  // 클라이언트 WebSocket 연결 지점
                 .setAllowedOriginPatterns(
                         "*",
-                        "https://assu.shop",
+                        "https://assu.site",
                         "http://localhost:63342",
                         "http://localhost:5173",     // Vite 기본
                         "http://localhost:3000",     // CRA/Next 기본


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #362

## 📝작업 내용
> 백오피스 푸시 알림 그룹 발송 및 문의 키워드 검색 구현

---

### 요약

`POST /backoffice/notifications/push` — 기존 단건 전송에서 그룹(전체/역할별)/개인 자유 메시지 발송으로 전면 교체
`GET /backoffice/notifications` — 발송 이력 조회 신규 구현
`GET /backoffice/inquiries` — `keyword` 파라미터 추가 (제목/본문 검색)

---

### A. 신규 엔티티 · DTO · Repository

| 파일 | 변경 | 설명 |
|------|------|------|
| `PushTargetType.java` | **신규** | `ALL / STUDENT / UNION / PARTNER / INDIVIDUAL` |
| `BackofficePushLog.java` | **신규** | 푸시 발송 이력 엔티티 (targetType, recipientCount, sentAt 등) |
| `BackofficePushLogRepository.java` | **신규** | 이력 전체 조회 및 keyword(title/body) 검색 |
| `BackofficePushSendRequestDTO.java` | **신규** | 자유 메시지 푸시 요청 DTO (기존 `BackofficePushRequestDTO` 대체) |
| `BackofficePushLogResponseDTO.java` | **신규** | 발송 이력 응답 DTO |

---

### B. 백오피스 알림 서비스

| 파일 | 변경 | 설명 |
|------|------|------|
| `BackofficeNotificationService.java` | 수정 | `sendPush` 시그니처 교체, `getPushLogs` 추가 |
| `BackofficeNotificationServiceImpl.java` | 수정 | `targetType`별 수신자 분기(ALL/STUDENT/UNION/PARTNER/INDIVIDUAL) + `BackofficePushLog` 저장 |
| `BackofficeNotificationController.java` | 수정 | `POST /push` DTO 교체, `GET /backoffice/notifications` 추가 |
| `BackofficePushRequestDTO.java` | **삭제** | 구 DTO 제거 |

---

### C. 알림 공통 서비스

| 파일 | 변경 | 설명 |
|------|------|------|
| `NotificationCommandService.java` | 수정 | `createAndQueue(receiverId, title, body, deepLink)` 자유 메시지 오버로드 추가 |
| `NotificationCommandServiceImpl.java` | 수정 | 자유 메시지 오버로드 구현 (`NotificationType.BACKOFFICE` 사용) |
| `NotificationType.java` | 수정 | `BACKOFFICE` 타입 추가 |
| `MemberRepository.java` | 수정 | `findByRole(UserRole)` 추가 |

---

### D. 문의 키워드 검색

| 파일 | 변경 | 설명 |
|------|------|------|
| `InquiryRepository.java` | 수정 | `findByStatusAndTitleContainingOrStatusAndContentContaining`, `findByTitleContainingOrContentContaining` 추가 |
| `InquiryService.java` | 수정 | `getAllInquiries` 시그니처에 `keyword` 추가 |
| `InquiryServiceImpl.java` | 수정 | keyword + status 조합 분기 처리 |
| `BackofficeInquiryController.java` | 수정 | `GET /backoffice/inquiries`에 `keyword` 파라미터 추가 |

---

## 🔎코드 설명(스크린샷(선택))
프론트엔드 수정, 삭제가 필요한 부분들은 아래를 참고해 주세요
<img width="757" height="482" alt="스크린샷 2026-07-04 오후 2 48 28" src="https://github.com/user-attachments/assets/8bdd4b16-9e86-4acc-8a86-aee410fd6653" />


## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.