### PR TITLE
[FEAT/#368] 백오피스 회원관리 관련 API

### DIFF
--- a/src/main/java/com/assu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/assu/server/domain/auth/controller/AuthController.java
@@ -185,11 +185,12 @@ public class AuthController {
 
     @Operation(
             summary = "제휴업체 회원가입 API",
-            description = "# [v1.2 (2025-09-13)](https://clumsy-seeder-416.notion.site/2501197c19ed80d7a8f2c3a6fcd8b537)\n" +
+            description = "# [v1.3 (2026-07-03)](https://clumsy-seeder-416.notion.site/2501197c19ed80d7a8f2c3a6fcd8b537)\n" +
                     "- `multipart/form-data`로 호출합니다.\n" +
                     "- 파트: `request`(JSON, PartnerSignUpRequestDTO) + `licenseImage`(파일, 사업자등록증).\n" +
                     "- 처리: users + common_auth 생성, 이메일 중복/비밀번호 규칙 검증.\n" +
-                    "- 성공 시 200(OK)과 생성된 memberId, JWT 토큰, 기본 정보 반환.\n" +
+                    "- 가입 직후 `SUSPEND` 상태이며 JWT는 발급되지 않습니다. 백오피스 승인 후 로그인 가능합니다.\n" +
+                    "- 성공 시 200(OK)과 생성된 memberId, 기본 정보 반환.\n" +
                     "\n**Request Parts:**\n" +
                     "  - `request` (JSON, required): `PartnerSignUpRequestDTO` 객체\n" +
                     "    - `phoneNumber` (String, required): 휴대폰 번호\n" +
@@ -216,8 +217,8 @@ public class AuthController {
                     "  - 성공 시 200(OK)과 `SignUpResponseDTO` 객체 반환\n" +
                     "  - `memberId` (Long): 회원 ID\n" +
                     "  - `role` (UserRole): 회원 역할 (PARTNER)\n" +
-                    "  - `status` (ActivationStatus): 회원 상태 (ACTIVE)\n" +
-                    "  - `tokens` (Object): JWT 토큰 정보 (accessToken, refreshToken)\n" +
+                    "  - `status` (ActivationStatus): 회원 상태 (SUSPEND)\n" +
+                    "  - `tokens` (Object): 승인 전까지 null\n" +
                     "  - `basicInfo` (UserBasicInfo): 사용자 기본 정보 (프론트 캐싱용)\n" +
                     "    - `name` (String): 업체명\n" +
                     "    - `university` (String): null (Partner는 해당 없음)\n" +
@@ -253,11 +254,12 @@ public class AuthController {
 
     @Operation(
             summary = "관리자 회원가입 API",
-            description = "# [v1.2 (2025-09-13)](https://clumsy-seeder-416.notion.site/2501197c19ed80cdb98bc2b4d5042b48)\n" +
+            description = "# [v1.3 (2026-07-03)](https://clumsy-seeder-416.notion.site/2501197c19ed80cdb98bc2b4d5042b48)\n" +
                     "- `multipart/form-data`로 호출합니다.\n" +
                     "- 파트: `request`(JSON, AdminSignUpRequestDTO) + `signImage`(파일, 신분증).\n" +
                     "- 처리: users + common_auth 생성, 이메일 중복/비밀번호 규칙 검증.\n" +
-                    "- 성공 시 200(OK)과 생성된 memberId, JWT 토큰, 기본 정보 반환.\n" +
+                    "- 가입 직후 `SUSPEND` 상태이며 JWT는 발급되지 않습니다. 백오피스 승인 후 로그인 가능합니다.\n" +
+                    "- 성공 시 200(OK)과 생성된 memberId, 기본 정보 반환.\n" +
                     "\n**Request Parts:**\n" +
                     "  - `request` (JSON, required): `AdminSignUpRequestDTO` 객체\n" +
                     "    - `phoneNumber` (String, required): 휴대폰 번호\n" +
@@ -284,8 +286,8 @@ public class AuthController {
                     "  - 성공 시 200(OK)과 `SignUpResponseDTO` 객체 반환\n" +
                     "  - `memberId` (Long): 회원 ID\n" +
                     "  - `role` (UserRole): 회원 역할 (ADMIN)\n" +
-                    "  - `status` (ActivationStatus): 회원 상태 (ACTIVE)\n" +
-                    "  - `tokens` (Object): JWT 토큰 정보 (accessToken, refreshToken)\n" +
+                    "  - `status` (ActivationStatus): 회원 상태 (SUSPEND)\n" +
+                    "  - `tokens` (Object): 승인 전까지 null\n" +
                     "  - `basicInfo` (UserBasicInfo): 사용자 기본 정보 (프론트 캐싱용)\n" +
                     "    - `name` (String): 단체명/관리자 이름\n" +
                     "    - `university` (String): 대학교 (한글명)\n" +
@@ -321,10 +323,11 @@ public class AuthController {
 
     @Operation(
             summary = "공통 로그인 API",
-            description = "# [v1.1 (2025-09-13)](https://clumsy-seeder-416.notion.site/2241197c19ed811c961be6a474de0e50)\n" +
+            description = "# [v1.2 (2026-07-03)](https://clumsy-seeder-416.notion.site/2241197c19ed811c961be6a474de0e50)\n" +
                     "- `application/json`로 호출합니다.\n" +
                     "- 바디: `CommonLoginRequestDTO(email, password)`.\n" +
                     "- 처리: 자격 증명 검증 후 Access/Refresh 토큰 발급 및 저장.\n" +
+                    "- `SUSPEND`(승인 대기) 상태 계정은 자격 증명이 맞아도 로그인할 수 없습니다.\n" +
                     "- 성공 시 200(OK)과 토큰(accessToken/refreshToken), 기본 정보 반환.\n" +
                     "\n**Request Body:**\n" +
                     "  - `CommonLoginRequestDTO` 객체 (JSON, required): 로그인 정보\n" +
@@ -340,7 +343,10 @@ public class AuthController {
                     "    - `name` (String): 업체명/단체명/관리자 이름\n" +
                     "    - `university` (String): Admin인 경우 한글명, Partner인 경우 null\n" +
                     "    - `department` (String): Admin인 경우 한글명, Partner인 경우 null\n" +
-                    "    - `major` (String): Admin인 경우 한글명, Partner인 경우 null"
+                    "    - `major` (String): Admin인 경우 한글명, Partner인 경우 null\n" +
+                    "  - 403(FORBIDDEN): `MEMBER_4018` — 가입 승인 대기(`SUSPEND`) 상태\n" +
+                    "  - 403(FORBIDDEN): `BACKOFFICE4003` — BACKOFFICE 계정은 `/auth/backoffice/login` 사용\n" +
+                    "  - 401(UNAUTHORIZED): 이메일/비밀번호 불일치"
     )
     @PostMapping(value = "/commons/login", consumes = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<LoginResponseDTO> loginCommon(

--- a/src/main/java/com/assu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/assu/server/domain/auth/controller/AuthController.java
@@ -344,7 +344,7 @@ public class AuthController {
                     "    - `university` (String): Admin인 경우 한글명, Partner인 경우 null\n" +
                     "    - `department` (String): Admin인 경우 한글명, Partner인 경우 null\n" +
                     "    - `major` (String): Admin인 경우 한글명, Partner인 경우 null\n" +
-                    "  - 403(FORBIDDEN): `MEMBER_4018` — 가입 승인 대기(`SUSPEND`) 상태\n" +
+                    "  - 403(FORBIDDEN): `MEMBER_4017` — 가입 승인 대기(`SUSPEND`) 상태\n" +
                     "  - 403(FORBIDDEN): `BACKOFFICE4003` — BACKOFFICE 계정은 `/auth/backoffice/login` 사용\n" +
                     "  - 401(UNAUTHORIZED): 이메일/비밀번호 불일치"
     )

--- a/src/main/java/com/assu/server/domain/auth/security/adapter/CommonAuthAdapter.java
+++ b/src/main/java/com/assu/server/domain/auth/security/adapter/CommonAuthAdapter.java
@@ -4,16 +4,19 @@ import com.assu.server.domain.auth.entity.enums.AuthRealm;
 import com.assu.server.domain.auth.entity.CommonAuth;
 import com.assu.server.domain.auth.exception.CustomAuthException;
 import com.assu.server.domain.auth.repository.CommonAuthRepository;
+import com.assu.server.domain.auth.security.userdetails.CommonUserDetails;
 import com.assu.server.domain.common.enums.ActivationStatus;
 import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.member.repository.MemberRepository;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -33,17 +36,19 @@ public class CommonAuthAdapter implements RealmAuthAdapter {
         CommonAuth ca = commonAuthRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
         var m = ca.getMember();
+        // SUSPEND는 비밀번호 검증 이후에 차단해야 하므로(이메일 열거 방지) enabled로 둔다
         boolean enabled = m.getIsActivated() == ActivationStatus.ACTIVE
                 || m.getIsActivated() == ActivationStatus.SUSPEND;
         String authority = "ROLE_" + m.getRole().name();
 
-        return org.springframework.security.core.userdetails.User
-                .withUsername(ca.getEmail())
-                .password(ca.getHashedPassword()) // BCrypt 해시
-                .authorities(authority)
-                .accountExpired(false).accountLocked(false).credentialsExpired(false)
-                .disabled(!enabled)
-                .build();
+        return new CommonUserDetails(
+                ca.getEmail(),
+                ca.getHashedPassword(), // BCrypt 해시
+                enabled,
+                List.of(new SimpleGrantedAuthority(authority)),
+                m.getIsActivated(),
+                m.getRole()
+        );
     }
 
     @Override

--- a/src/main/java/com/assu/server/domain/auth/security/adapter/CommonAuthAdapter.java
+++ b/src/main/java/com/assu/server/domain/auth/security/adapter/CommonAuthAdapter.java
@@ -33,7 +33,8 @@ public class CommonAuthAdapter implements RealmAuthAdapter {
         CommonAuth ca = commonAuthRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
         var m = ca.getMember();
-        boolean enabled = m.getIsActivated() == ActivationStatus.ACTIVE;
+        boolean enabled = m.getIsActivated() == ActivationStatus.ACTIVE
+                || m.getIsActivated() == ActivationStatus.SUSPEND;
         String authority = "ROLE_" + m.getRole().name();
 
         return org.springframework.security.core.userdetails.User

--- a/src/main/java/com/assu/server/domain/auth/security/userdetails/CommonUserDetails.java
+++ b/src/main/java/com/assu/server/domain/auth/security/userdetails/CommonUserDetails.java
@@ -1,0 +1,33 @@
+package com.assu.server.domain.auth.security.userdetails;
+
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+/**
+ * 공통(이메일/비밀번호) 로그인용 UserDetails.
+ * 인증 이후 추가 조회 없이 SUSPEND/역할 검사를 할 수 있도록 status와 role을 함께 담는다.
+ */
+@Getter
+public class CommonUserDetails extends User {
+
+    private final ActivationStatus status;
+    private final UserRole role;
+
+    public CommonUserDetails(
+            String username,
+            String password,
+            boolean enabled,
+            Collection<? extends GrantedAuthority> authorities,
+            ActivationStatus status,
+            UserRole role
+    ) {
+        super(username, password, enabled, true, true, true, authorities);
+        this.status = status;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/assu/server/domain/auth/service/LoginServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/auth/service/LoginServiceImpl.java
@@ -14,6 +14,7 @@ import com.assu.server.domain.auth.security.adapter.RealmAuthAdapter;
 import com.assu.server.domain.auth.security.jwt.JwtUtil;
 import com.assu.server.domain.auth.security.token.LoginUsernamePasswordAuthenticationToken;
 import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.enums.ActivationStatus;
 import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.student.entity.Student;
@@ -39,6 +40,7 @@ public class LoginServiceImpl implements LoginService {
     private final JwtUtil jwtUtil;
     private final SSUAuthService ssuAuthService;
     private final StudentRepository studentRepository;
+    private final CommonAuthRepository commonAuthRepository;
 
     private final List<RealmAuthAdapter> realmAuthAdapters;
 
@@ -66,13 +68,19 @@ public class LoginServiceImpl implements LoginService {
 
         RealmAuthAdapter adapter = pickAdapter(AuthRealm.COMMON);
 
-        Member member = adapter.loadMember(authentication.getName());
+        Member memberPreview = commonAuthRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER))
+                .getMember();
 
-        if (member.getRole() == UserRole.BACKOFFICE) {
+        if (memberPreview.getIsActivated() == ActivationStatus.SUSPEND) {
+            throw new CustomAuthException(ErrorStatus.MEMBER_PENDING_APPROVAL);
+        }
+
+        if (memberPreview.getRole() == UserRole.BACKOFFICE) {
             throw new GeneralException(ErrorStatus.BACKOFFICE_USE_DEDICATED_LOGIN);
         }
 
-        // 토큰 발급 (Access 미저장, Refresh는 Redis 저장)
+        Member member = adapter.loadMember(authentication.getName());
         TokensDTO tokens = jwtUtil.issueTokens(
                 member.getId(),
                 authentication.getName(),

--- a/src/main/java/com/assu/server/domain/auth/service/LoginServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/auth/service/LoginServiceImpl.java
@@ -9,8 +9,8 @@ import com.assu.server.domain.auth.dto.ssu.USaintAuthRequestDTO;
 import com.assu.server.domain.auth.dto.ssu.USaintAuthResponseDTO;
 import com.assu.server.domain.auth.entity.enums.AuthRealm;
 import com.assu.server.domain.auth.exception.CustomAuthException;
-import com.assu.server.domain.auth.repository.CommonAuthRepository;
 import com.assu.server.domain.auth.security.adapter.RealmAuthAdapter;
+import com.assu.server.domain.auth.security.userdetails.CommonUserDetails;
 import com.assu.server.domain.auth.security.jwt.JwtUtil;
 import com.assu.server.domain.auth.security.token.LoginUsernamePasswordAuthenticationToken;
 import com.assu.server.domain.common.entity.enums.Major;
@@ -40,7 +40,6 @@ public class LoginServiceImpl implements LoginService {
     private final JwtUtil jwtUtil;
     private final SSUAuthService ssuAuthService;
     private final StudentRepository studentRepository;
-    private final CommonAuthRepository commonAuthRepository;
 
     private final List<RealmAuthAdapter> realmAuthAdapters;
 
@@ -68,15 +67,14 @@ public class LoginServiceImpl implements LoginService {
 
         RealmAuthAdapter adapter = pickAdapter(AuthRealm.COMMON);
 
-        Member memberPreview = commonAuthRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER))
-                .getMember();
+        // 인증 시 조회한 principal에 status/role이 담겨 있어 추가 조회 없이 검사한다
+        CommonUserDetails userDetails = (CommonUserDetails) authentication.getPrincipal();
 
-        if (memberPreview.getIsActivated() == ActivationStatus.SUSPEND) {
+        if (userDetails.getStatus() == ActivationStatus.SUSPEND) {
             throw new CustomAuthException(ErrorStatus.MEMBER_PENDING_APPROVAL);
         }
 
-        if (memberPreview.getRole() == UserRole.BACKOFFICE) {
+        if (userDetails.getRole() == UserRole.BACKOFFICE) {
             throw new GeneralException(ErrorStatus.BACKOFFICE_USE_DEDICATED_LOGIN);
         }
 

--- a/src/main/java/com/assu/server/domain/auth/service/SignUpServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/auth/service/SignUpServiceImpl.java
@@ -132,7 +132,7 @@ public class SignUpServiceImpl implements SignUpService {
                         .isLocationTermAgreed(req.locationAgree())
                         .isMarketingTermAgreed(req.marketingAgree())
                         .role(UserRole.PARTNER)
-                        .isActivated(ActivationStatus.ACTIVE) // Todo 초기에 SUSPEND 로직 추가해야함, 허가 후 ACTIVE
+                        .isActivated(ActivationStatus.SUSPEND)
                         .build());
 
         // 2) RealmAuthAdapter 로 Common 자격 저장
@@ -179,7 +179,7 @@ public class SignUpServiceImpl implements SignUpService {
             Store newly = Store.builder()
                     .partner(partner)
                     .rate(0)
-                    .isActivate(ActivationStatus.ACTIVE)
+                    .isActivate(ActivationStatus.SUSPEND)
                     .name(info.name())
                     .address(address)
                     .detailAddress(info.detailAddress())
@@ -190,16 +190,7 @@ public class SignUpServiceImpl implements SignUpService {
             storeRepository.save(newly);
         }
 
-        // 4) 토큰 발급
-        TokensDTO tokens = jwtUtil.issueTokens(
-                member.getId(),
-                req.commonAuth().email(),
-                UserRole.PARTNER,
-                adapter.authRealmValue()
-        );
-
-        // 5) SignUpResponseDTO 생성
-        return SignUpResponseDTO.from(member, tokens);
+        return SignUpResponseDTO.from(member, null);
     }
 
     @Override
@@ -215,7 +206,7 @@ public class SignUpServiceImpl implements SignUpService {
                         .isLocationTermAgreed(req.locationAgree())
                         .isMarketingTermAgreed(req.marketingAgree())
                         .role(UserRole.ADMIN)
-                        .isActivated(ActivationStatus.ACTIVE) // Todo 초기에 SUSPEND 로직 추가해야함, 허가 후 ACTIVE
+                        .isActivated(ActivationStatus.SUSPEND)
                         .build());
 
         // 2) RealmAuthAdapter 로 Common 자격 저장
@@ -254,15 +245,7 @@ public class SignUpServiceImpl implements SignUpService {
                         .build());
         member.setProfile(admin);
 
-        // 4) 토큰 발급
-        TokensDTO tokens = jwtUtil.issueTokens(
-                member.getId(),
-                req.commonAuth().email(),
-                UserRole.ADMIN,
-                adapter.authRealmValue());
-
-        // 5) SignUpResponseDTO 생성
-        return SignUpResponseDTO.from(member, tokens);
+        return SignUpResponseDTO.from(member, null);
     }
 
     private EnrollmentStatus parseEnrollmentStatus(String status) {

--- a/src/main/java/com/assu/server/domain/auth/service/WithdrawalService.java
+++ b/src/main/java/com/assu/server/domain/auth/service/WithdrawalService.java
@@ -2,4 +2,5 @@ package com.assu.server.domain.auth.service;
 
 public interface WithdrawalService {
     void withdrawCurrentUser(String authorization);
+    void withdrawMember(Long memberId);
 }

--- a/src/main/java/com/assu/server/domain/auth/service/WithdrawalService.java
+++ b/src/main/java/com/assu/server/domain/auth/service/WithdrawalService.java
@@ -1,6 +1,9 @@
 package com.assu.server.domain.auth.service;
 
+import com.assu.server.domain.member.entity.Member;
+
 public interface WithdrawalService {
     void withdrawCurrentUser(String authorization);
     void withdrawMember(Long memberId);
+    void withdrawMember(Member member);
 }

--- a/src/main/java/com/assu/server/domain/auth/service/WithdrawalServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/auth/service/WithdrawalServiceImpl.java
@@ -32,7 +32,8 @@ public class WithdrawalServiceImpl implements WithdrawalService {
         jwtUtil.blacklistAccess(rawAccessToken);
     }
 
-    private void withdrawMember(Long memberId) {
+    @Override
+    public void withdrawMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
 

--- a/src/main/java/com/assu/server/domain/auth/service/WithdrawalServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/auth/service/WithdrawalServiceImpl.java
@@ -36,7 +36,11 @@ public class WithdrawalServiceImpl implements WithdrawalService {
     public void withdrawMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+        withdrawMember(member);
+    }
 
+    @Override
+    public void withdrawMember(Member member) {
         if (member.getDeletedAt() != null) {
             throw new CustomAuthException(ErrorStatus.MEMBER_ALREADY_WITHDRAWN);
         }
@@ -45,6 +49,6 @@ public class WithdrawalServiceImpl implements WithdrawalService {
         member.setDeletedAt(java.time.LocalDateTime.now());
         memberRepository.save(member);
 
-        jwtUtil.removeAllRefreshTokens(memberId);
+        jwtUtil.removeAllRefreshTokens(member.getId());
     }
 }

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeAdminController.java
@@ -1,0 +1,48 @@
+package com.assu.server.domain.backoffice.controller;
+
+import com.assu.server.domain.backoffice.dto.BackofficeDocumentUrlResponseDTO;
+import com.assu.server.domain.backoffice.service.BackofficeMemberService;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/admins")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficeAdminController {
+
+    private final BackofficeMemberService backofficeMemberService;
+
+    @Operation(
+            summary = "인감 이미지 조회 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- Admin 회원의 인감 이미지 S3 presigned URL을 반환합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): Admin 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 presigned URL 반환 (약 10분 유효)\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): Admin이 아니거나 인감 이미지 없음"
+    )
+    @GetMapping("/{memberId}/sign-image")
+    public BaseResponse<BackofficeDocumentUrlResponseDTO> getSignImageUrl(
+            @Parameter(description = "Admin 회원 ID") @PathVariable Long memberId
+    ) {
+        return BaseResponse.onSuccess(
+                SuccessStatus._OK,
+                backofficeMemberService.getAdminSignImageUrl(memberId)
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeMemberController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeMemberController.java
@@ -113,7 +113,8 @@ public class BackofficeMemberController {
     @Operation(
             summary = "회원 가입 승인 API",
             description = "# [v1.0 (2026-07-03)]\n" +
-                    "- `SUSPEND` 상태의 ADMIN/PARTNER 회원을 `ACTIVE`로 승인합니다.\n" +
+                    "- `SUSPEND`(대기) 또는 `INACTIVE`(거절) 상태의 ADMIN/PARTNER 회원을 `ACTIVE`로 승인합니다.\n" +
+                    "- 거절된 회원도 재승인할 수 있습니다.\n" +
                     "- Partner는 사업자등록증 검증 완료 처리 및 Store 활성화를 함께 수행합니다.\n" +
                     "- Admin은 인감 검증 완료 처리를 함께 수행합니다.\n" +
                     "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
@@ -121,7 +122,7 @@ public class BackofficeMemberController {
                     "- `memberId` (Long, required): 회원 ID\n\n" +
                     "**Response:**\n" +
                     "- 성공 시 200(OK)과 `BackofficeMemberSummaryDTO` 반환\n" +
-                    "- 400(BAD_REQUEST): 승인 대기 상태가 아님\n" +
+                    "- 400(BAD_REQUEST): 이미 승인(ACTIVE)된 회원\n" +
                     "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
                     "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
                     "- 404(NOT_FOUND): 존재하지 않는 회원 ID"

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeMemberController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeMemberController.java
@@ -1,0 +1,196 @@
+package com.assu.server.domain.backoffice.controller;
+
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberDetailDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberSummaryDTO;
+import com.assu.server.domain.backoffice.service.BackofficeMemberService;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/members")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficeMemberController {
+
+    private final BackofficeMemberService backofficeMemberService;
+
+    @Operation(
+            summary = "회원 목록 조회 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- STUDENT/ADMIN/PARTNER 회원 목록을 페이지네이션으로 조회합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Query Parameters:**\n" +
+                    "- `role` (UserRole, optional): 역할 필터\n" +
+                    "- `status` (ActivationStatus, optional): 활성화 상태 필터\n" +
+                    "- `deleted` (Boolean, optional): true=탈퇴 회원만, false=활성 회원만, omit=전체\n" +
+                    "- `page`, `size`, `sort` (Pageable)\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `PageResponseDTO<BackofficeMemberSummaryDTO>` 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음"
+    )
+    @GetMapping
+    public BaseResponse<PageResponseDTO<BackofficeMemberSummaryDTO>> listMembers(
+            @RequestParam(required = false) UserRole role,
+            @RequestParam(required = false) ActivationStatus status,
+            @RequestParam(required = false) Boolean deleted,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(
+                SuccessStatus._OK,
+                backofficeMemberService.listMembers(role, status, deleted, pageable)
+        );
+    }
+
+    @Operation(
+            summary = "탈퇴 회원 목록 조회 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- `deletedAt`이 설정된 회원 목록을 조회합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `PageResponseDTO<BackofficeMemberSummaryDTO>` 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음"
+    )
+    @GetMapping("/deleted")
+    public BaseResponse<PageResponseDTO<BackofficeMemberSummaryDTO>> listDeletedMembers(
+            @PageableDefault(size = 20, sort = "deletedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(
+                SuccessStatus._OK,
+                backofficeMemberService.listDeletedMembers(pageable)
+        );
+    }
+
+    @Operation(
+            summary = "회원 상세 조회 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- 회원 ID로 상세 정보를 조회합니다.\n" +
+                    "- 역할별 프로필 필드를 `base` + `student`/`admin`/`partner` 중 하나로 반환합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `BackofficeMemberDetailDTO` 반환\n" +
+                    "  - `base` (BackofficeMemberBaseDetailDTO): 공통 회원 정보\n" +
+                    "  - `student` (BackofficeStudentProfileDetailDTO): STUDENT일 때만\n" +
+                    "  - `admin` (BackofficeAdminProfileDetailDTO): ADMIN일 때만\n" +
+                    "  - `partner` (BackofficePartnerProfileDetailDTO): PARTNER일 때만\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 회원 ID"
+    )
+    @GetMapping("/{memberId}")
+    public BaseResponse<BackofficeMemberDetailDTO> getMemberDetail(
+            @Parameter(description = "회원 ID") @PathVariable Long memberId
+    ) {
+        return BaseResponse.onSuccess(
+                SuccessStatus._OK,
+                backofficeMemberService.getMemberDetail(memberId)
+        );
+    }
+
+    @BackofficeAudited(action = "MEMBER_APPROVE", targetId = "#memberId")
+    @Operation(
+            summary = "회원 가입 승인 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- `SUSPEND` 상태의 ADMIN/PARTNER 회원을 `ACTIVE`로 승인합니다.\n" +
+                    "- Partner는 사업자등록증 검증 완료 처리 및 Store 활성화를 함께 수행합니다.\n" +
+                    "- Admin은 인감 검증 완료 처리를 함께 수행합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `BackofficeMemberSummaryDTO` 반환\n" +
+                    "- 400(BAD_REQUEST): 승인 대기 상태가 아님\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 회원 ID"
+    )
+    @PatchMapping("/{memberId}/approve")
+    public BaseResponse<BackofficeMemberSummaryDTO> approveMember(@PathVariable Long memberId) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeMemberService.approveMember(memberId));
+    }
+
+    @BackofficeAudited(action = "MEMBER_REJECT", targetId = "#memberId")
+    @Operation(
+            summary = "회원 가입 거절 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- `SUSPEND` 상태의 ADMIN/PARTNER 회원을 `INACTIVE`로 거절합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `BackofficeMemberSummaryDTO` 반환\n" +
+                    "- 400(BAD_REQUEST): 승인 대기 상태가 아님\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 회원 ID"
+    )
+    @PatchMapping("/{memberId}/reject")
+    public BaseResponse<BackofficeMemberSummaryDTO> rejectMember(@PathVariable Long memberId) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeMemberService.rejectMember(memberId));
+    }
+
+    @BackofficeAudited(action = "MEMBER_FORCE_WITHDRAW", targetId = "#memberId")
+    @Operation(
+            summary = "회원 강제 탈퇴 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- 회원을 소프트 탈퇴 처리하고 refresh token을 삭제합니다.\n" +
+                    "- BACKOFFICE 운영자는 강제 탈퇴할 수 없습니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)\n" +
+                    "- 400(BAD_REQUEST): 이미 탈퇴된 회원 또는 BACKOFFICE 대상\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 회원 ID"
+    )
+    @PatchMapping("/{memberId}/force-withdraw")
+    public BaseResponse<String> forceWithdrawMember(@PathVariable Long memberId) {
+        backofficeMemberService.forceWithdrawMember(memberId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, "회원이 강제 탈퇴 처리되었습니다.");
+    }
+
+    @BackofficeAudited(action = "MEMBER_RESTORE", targetId = "#memberId")
+    @Operation(
+            summary = "탈퇴 회원 복구 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- `deletedAt`을 null로 설정하여 탈퇴 회원을 복구합니다.\n" +
+                    "- `isActivated` 상태는 변경하지 않습니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `BackofficeMemberSummaryDTO` 반환\n" +
+                    "- 400(BAD_REQUEST): 탈퇴 상태가 아님\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): 존재하지 않는 회원 ID"
+    )
+    @PatchMapping("/{memberId}/restore")
+    public BaseResponse<BackofficeMemberSummaryDTO> restoreMember(@PathVariable Long memberId) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeMemberService.restoreMember(memberId));
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnerController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficePartnerController.java
@@ -1,0 +1,71 @@
+package com.assu.server.domain.backoffice.controller;
+
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.dto.BackofficeDocumentUrlResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberSummaryDTO;
+import com.assu.server.domain.backoffice.service.BackofficeMemberService;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Backoffice", description = "백오피스 운영 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/partners")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficePartnerController {
+
+    private final BackofficeMemberService backofficeMemberService;
+
+    @Operation(
+            summary = "사업자등록증 조회 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- Partner 회원의 사업자등록증 S3 presigned URL을 반환합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): Partner 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 presigned URL 반환 (약 10분 유효)\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): Partner가 아니거나 사업자등록증 없음"
+    )
+    @GetMapping("/{memberId}/license")
+    public BaseResponse<BackofficeDocumentUrlResponseDTO> getLicenseUrl(
+            @Parameter(description = "Partner 회원 ID") @PathVariable Long memberId
+    ) {
+        return BaseResponse.onSuccess(
+                SuccessStatus._OK,
+                backofficeMemberService.getPartnerLicenseUrl(memberId)
+        );
+    }
+
+    @BackofficeAudited(action = "PARTNER_LICENSE_VERIFY", targetId = "#memberId")
+    @Operation(
+            summary = "사업자등록증 검증 API",
+            description = "# [v1.0 (2026-07-03)]\n" +
+                    "- Partner 회원의 사업자등록증을 검증 완료 처리합니다.\n" +
+                    "- 가입 승인과 독립적으로 동작합니다.\n" +
+                    "- `BACKOFFICE` 역할 및 `aud=backoffice` JWT가 필요합니다.\n\n" +
+                    "**Path Variable:**\n" +
+                    "- `memberId` (Long, required): Partner 회원 ID\n\n" +
+                    "**Response:**\n" +
+                    "- 성공 시 200(OK)과 `BackofficeMemberSummaryDTO` 반환\n" +
+                    "- 401(UNAUTHORIZED): 인증되지 않았거나 audience 불일치\n" +
+                    "- 403(FORBIDDEN): BACKOFFICE 권한 없음\n" +
+                    "- 404(NOT_FOUND): Partner가 아니거나 사업자등록증 없음"
+    )
+    @PatchMapping("/{memberId}/license/verify")
+    public BaseResponse<BackofficeMemberSummaryDTO> verifyLicense(@PathVariable Long memberId) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeMemberService.verifyPartnerLicense(memberId));
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminProfileDetailDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeAdminProfileDetailDTO.java
@@ -1,0 +1,46 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.common.entity.enums.Department;
+import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.entity.enums.University;
+import com.assu.server.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "백오피스 관리자 프로필 상세")
+public record BackofficeAdminProfileDetailDTO(
+        @Schema(description = "이름") String name,
+        @Schema(description = "이메일") String email,
+        @Schema(description = "전화번호") String phoneNum,
+        @Schema(description = "사무실 주소") String officeAddress,
+        @Schema(description = "상세 주소") String detailAddress,
+        @Schema(description = "대학교") University university,
+        @Schema(description = "단과대") Department department,
+        @Schema(description = "전공") Major major,
+        @Schema(description = "인감 검증 여부") Boolean isSignVerified,
+        @Schema(description = "인감 검증 시각") LocalDateTime signVerifiedAt
+) {
+    public static BackofficeAdminProfileDetailDTO from(Member member) {
+        Admin admin = member.getAdminProfile();
+        if (admin == null) {
+            return null;
+        }
+
+        String email = member.getCommonAuth() != null ? member.getCommonAuth().getEmail() : null;
+
+        return new BackofficeAdminProfileDetailDTO(
+                admin.getName(),
+                email,
+                admin.getPhoneNum(),
+                admin.getOfficeAddress(),
+                admin.getDetailAddress(),
+                admin.getUniversity(),
+                admin.getDepartment(),
+                admin.getMajor(),
+                admin.getIsSignVerified(),
+                admin.getSignVerifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeDocumentUrlResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeDocumentUrlResponseDTO.java
@@ -1,0 +1,12 @@
+package com.assu.server.domain.backoffice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "백오피스 서류 presigned URL 응답")
+public record BackofficeDocumentUrlResponseDTO(
+        @Schema(description = "S3 presigned URL (약 10분 유효)") String url
+) {
+    public static BackofficeDocumentUrlResponseDTO of(String url) {
+        return new BackofficeDocumentUrlResponseDTO(url);
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberBaseDetailDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberBaseDetailDTO.java
@@ -1,0 +1,31 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "백오피스 회원 공통 상세")
+public record BackofficeMemberBaseDetailDTO(
+        @Schema(description = "회원 ID") Long memberId,
+        @Schema(description = "회원 역할") UserRole role,
+        @Schema(description = "활성화 상태") ActivationStatus status,
+        @Schema(description = "탈퇴 시각") LocalDateTime deletedAt,
+        @Schema(description = "가입 시각") LocalDateTime createdAt,
+        @Schema(description = "위치 정보 수집 동의") Boolean isLocationTermAgreed,
+        @Schema(description = "마케팅 수신 동의") Boolean isMarketingTermAgreed
+) {
+    public static BackofficeMemberBaseDetailDTO from(Member member) {
+        return new BackofficeMemberBaseDetailDTO(
+                member.getId(),
+                member.getRole(),
+                member.getIsActivated(),
+                member.getDeletedAt(),
+                member.getCreatedAt(),
+                member.getIsLocationTermAgreed(),
+                member.getIsMarketingTermAgreed()
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberDetailDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberDetailDTO.java
@@ -1,0 +1,41 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "백오피스 회원 상세 (역할별 프로필 포함)")
+public record BackofficeMemberDetailDTO(
+        @Schema(description = "회원 공통 정보") BackofficeMemberBaseDetailDTO base,
+        @Schema(description = "학생 프로필 (STUDENT일 때만)") BackofficeStudentProfileDetailDTO student,
+        @Schema(description = "관리자 프로필 (ADMIN일 때만)") BackofficeAdminProfileDetailDTO admin,
+        @Schema(description = "제휴업체 프로필 (PARTNER일 때만)") BackofficePartnerProfileDetailDTO partner
+) {
+    public static BackofficeMemberDetailDTO fromStudent(Member member) {
+        return new BackofficeMemberDetailDTO(
+                BackofficeMemberBaseDetailDTO.from(member),
+                BackofficeStudentProfileDetailDTO.from(member),
+                null,
+                null
+        );
+    }
+
+    public static BackofficeMemberDetailDTO fromAdmin(Member member) {
+        return new BackofficeMemberDetailDTO(
+                BackofficeMemberBaseDetailDTO.from(member),
+                null,
+                BackofficeAdminProfileDetailDTO.from(member),
+                null
+        );
+    }
+
+    public static BackofficeMemberDetailDTO fromPartner(Member member) {
+        return new BackofficeMemberDetailDTO(
+                BackofficeMemberBaseDetailDTO.from(member),
+                null,
+                null,
+                BackofficePartnerProfileDetailDTO.from(member)
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberSummaryDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberSummaryDTO.java
@@ -21,7 +21,7 @@ public record BackofficeMemberSummaryDTO(
         @Schema(description = "인감 검증 여부 (Admin)") Boolean isSignVerified
 ) {
     public static BackofficeMemberSummaryDTO from(Member member) {
-        String name = resolveName(member);
+        String name = member.resolveName();
         String email = member.getCommonAuth() != null ? member.getCommonAuth().getEmail() : null;
         String studentNumber = member.getSsuAuth() != null ? member.getSsuAuth().getStudentNumber() : null;
         Boolean isLicenseVerified = member.getPartnerProfile() != null
@@ -41,14 +41,5 @@ public record BackofficeMemberSummaryDTO(
                 isLicenseVerified,
                 isSignVerified
         );
-    }
-
-    private static String resolveName(Member member) {
-        return switch (member.getRole()) {
-            case STUDENT -> member.getStudentProfile() != null ? member.getStudentProfile().getName() : null;
-            case ADMIN -> member.getAdminProfile() != null ? member.getAdminProfile().getName() : null;
-            case PARTNER -> member.getPartnerProfile() != null ? member.getPartnerProfile().getName() : null;
-            case BACKOFFICE -> member.getBackofficeProfile() != null ? member.getBackofficeProfile().getName() : null;
-        };
     }
 }

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberSummaryDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeMemberSummaryDTO.java
@@ -1,0 +1,54 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "백오피스 회원 목록 요약")
+public record BackofficeMemberSummaryDTO(
+        @Schema(description = "회원 ID") Long memberId,
+        @Schema(description = "회원 역할") UserRole role,
+        @Schema(description = "활성화 상태") ActivationStatus status,
+        @Schema(description = "이름/업체명/단체명") String name,
+        @Schema(description = "이메일 (CommonAuth)") String email,
+        @Schema(description = "학번 (SSUAuth, Student만)") String studentNumber,
+        @Schema(description = "탈퇴 시각") LocalDateTime deletedAt,
+        @Schema(description = "가입 시각") LocalDateTime createdAt,
+        @Schema(description = "사업자등록증 검증 여부 (Partner)") Boolean isLicenseVerified,
+        @Schema(description = "인감 검증 여부 (Admin)") Boolean isSignVerified
+) {
+    public static BackofficeMemberSummaryDTO from(Member member) {
+        String name = resolveName(member);
+        String email = member.getCommonAuth() != null ? member.getCommonAuth().getEmail() : null;
+        String studentNumber = member.getSsuAuth() != null ? member.getSsuAuth().getStudentNumber() : null;
+        Boolean isLicenseVerified = member.getPartnerProfile() != null
+                ? member.getPartnerProfile().getIsLicenseVerified() : null;
+        Boolean isSignVerified = member.getAdminProfile() != null
+                ? member.getAdminProfile().getIsSignVerified() : null;
+
+        return new BackofficeMemberSummaryDTO(
+                member.getId(),
+                member.getRole(),
+                member.getIsActivated(),
+                name,
+                email,
+                studentNumber,
+                member.getDeletedAt(),
+                member.getCreatedAt(),
+                isLicenseVerified,
+                isSignVerified
+        );
+    }
+
+    private static String resolveName(Member member) {
+        return switch (member.getRole()) {
+            case STUDENT -> member.getStudentProfile() != null ? member.getStudentProfile().getName() : null;
+            case ADMIN -> member.getAdminProfile() != null ? member.getAdminProfile().getName() : null;
+            case PARTNER -> member.getPartnerProfile() != null ? member.getPartnerProfile().getName() : null;
+            case BACKOFFICE -> member.getBackofficeProfile() != null ? member.getBackofficeProfile().getName() : null;
+        };
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePartnerProfileDetailDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficePartnerProfileDetailDTO.java
@@ -1,0 +1,37 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.partner.entity.Partner;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "백오피스 제휴업체 프로필 상세")
+public record BackofficePartnerProfileDetailDTO(
+        @Schema(description = "업체명") String name,
+        @Schema(description = "이메일") String email,
+        @Schema(description = "전화번호") String phoneNum,
+        @Schema(description = "주소") String address,
+        @Schema(description = "상세 주소") String detailAddress,
+        @Schema(description = "사업자등록증 검증 여부") Boolean isLicenseVerified,
+        @Schema(description = "사업자등록증 검증 시각") LocalDateTime licenseVerifiedAt
+) {
+    public static BackofficePartnerProfileDetailDTO from(Member member) {
+        Partner partner = member.getPartnerProfile();
+        if (partner == null) {
+            return null;
+        }
+
+        String email = member.getCommonAuth() != null ? member.getCommonAuth().getEmail() : null;
+
+        return new BackofficePartnerProfileDetailDTO(
+                partner.getName(),
+                email,
+                partner.getPhoneNum(),
+                partner.getAddress(),
+                partner.getDetailAddress(),
+                partner.getIsLicenseVerified(),
+                partner.getLicenseVerifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeStudentProfileDetailDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeStudentProfileDetailDTO.java
@@ -1,0 +1,44 @@
+package com.assu.server.domain.backoffice.dto;
+
+import com.assu.server.domain.common.entity.enums.Department;
+import com.assu.server.domain.common.entity.enums.EnrollmentStatus;
+import com.assu.server.domain.common.entity.enums.Major;
+import com.assu.server.domain.common.entity.enums.ReportedStatus;
+import com.assu.server.domain.common.entity.enums.University;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.student.entity.Student;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "백오피스 학생 프로필 상세")
+public record BackofficeStudentProfileDetailDTO(
+        @Schema(description = "이름") String name,
+        @Schema(description = "학번") String studentNumber,
+        @Schema(description = "대학교") University university,
+        @Schema(description = "단과대") Department department,
+        @Schema(description = "전공") Major major,
+        @Schema(description = "재학 상태") EnrollmentStatus enrollmentStatus,
+        @Schema(description = "학년/학기") String yearSemester,
+        @Schema(description = "신고 상태") ReportedStatus reportedStatus,
+        @Schema(description = "스탬프") Integer stamp
+) {
+    public static BackofficeStudentProfileDetailDTO from(Member member) {
+        Student student = member.getStudentProfile();
+        if (student == null) {
+            return null;
+        }
+
+        String studentNumber = member.getSsuAuth() != null ? member.getSsuAuth().getStudentNumber() : null;
+
+        return new BackofficeStudentProfileDetailDTO(
+                student.getName(),
+                studentNumber,
+                student.getUniversity(),
+                student.getDepartment(),
+                student.getMajor(),
+                student.getEnrollmentStatus(),
+                student.getYearSemester(),
+                student.getStatus(),
+                student.getStamp()
+        );
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeMemberService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeMemberService.java
@@ -1,0 +1,37 @@
+package com.assu.server.domain.backoffice.service;
+
+import com.assu.server.domain.backoffice.dto.BackofficeDocumentUrlResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberDetailDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberSummaryDTO;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import org.springframework.data.domain.Pageable;
+
+public interface BackofficeMemberService {
+
+    PageResponseDTO<BackofficeMemberSummaryDTO> listMembers(
+            UserRole role,
+            ActivationStatus status,
+            Boolean deleted,
+            Pageable pageable
+    );
+
+    PageResponseDTO<BackofficeMemberSummaryDTO> listDeletedMembers(Pageable pageable);
+
+    BackofficeMemberDetailDTO getMemberDetail(Long memberId);
+
+    BackofficeMemberSummaryDTO approveMember(Long memberId);
+
+    BackofficeMemberSummaryDTO rejectMember(Long memberId);
+
+    void forceWithdrawMember(Long memberId);
+
+    BackofficeMemberSummaryDTO restoreMember(Long memberId);
+
+    BackofficeDocumentUrlResponseDTO getPartnerLicenseUrl(Long memberId);
+
+    BackofficeMemberSummaryDTO verifyPartnerLicense(Long memberId);
+
+    BackofficeDocumentUrlResponseDTO getAdminSignImageUrl(Long memberId);
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeMemberServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeMemberServiceImpl.java
@@ -12,10 +12,12 @@ import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.member.repository.MemberRepository;
 import com.assu.server.domain.partner.entity.Partner;
+import com.assu.server.domain.store.entity.Store;
 import com.assu.server.domain.store.repository.StoreRepository;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
 import com.assu.server.infra.s3.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -70,7 +73,7 @@ public class BackofficeMemberServiceImpl implements BackofficeMemberService {
     public BackofficeMemberSummaryDTO approveMember(Long memberId) {
         Member member = findMemberWithRoleProfile(memberId);
         assertApprovalTarget(member);
-        assertPendingApproval(member);
+        assertApprovable(member);
 
         member.setIsActivated(ActivationStatus.ACTIVE);
         LocalDateTime now = LocalDateTime.now();
@@ -106,7 +109,7 @@ public class BackofficeMemberServiceImpl implements BackofficeMemberService {
         if (member.getRole() == UserRole.BACKOFFICE) {
             throw new CustomAuthException(ErrorStatus.CANNOT_WITHDRAW_BACKOFFICE_MEMBER);
         }
-        withdrawalService.withdrawMember(memberId);
+        withdrawalService.withdrawMember(member);
     }
 
     @Override
@@ -275,9 +278,20 @@ public class BackofficeMemberServiceImpl implements BackofficeMemberService {
         }
     }
 
+    // 승인은 대기(SUSPEND)뿐 아니라 거절(INACTIVE)된 회원의 재승인도 허용한다
+    private void assertApprovable(Member member) {
+        if (member.getIsActivated() == ActivationStatus.ACTIVE) {
+            throw new CustomAuthException(ErrorStatus.MEMBER_NOT_PENDING_APPROVAL);
+        }
+    }
+
     private void activatePartnerStore(Partner partner) {
-        storeRepository.findByPartner(partner).ifPresent(store -> {
-            store.setIsActivate(ActivationStatus.ACTIVE);
-        });
+        Store store = storeRepository.findByPartner(partner)
+                .orElseThrow(() -> {
+                    log.error("파트너 승인 실패: 연결된 스토어가 없습니다. partnerId={}", partner.getId());
+                    return new CustomAuthException(ErrorStatus.PARTNER_STORE_NOT_FOUND);
+                });
+        store.setIsActivate(ActivationStatus.ACTIVE);
+        log.info("파트너 스토어 활성화: partnerId={}, storeId={}", partner.getId(), store.getId());
     }
 }

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeMemberServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeMemberServiceImpl.java
@@ -1,0 +1,283 @@
+package com.assu.server.domain.backoffice.service;
+
+import com.assu.server.domain.admin.entity.Admin;
+import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.domain.auth.service.WithdrawalService;
+import com.assu.server.domain.backoffice.dto.BackofficeDocumentUrlResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberDetailDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberSummaryDTO;
+import com.assu.server.domain.common.dto.PageResponseDTO;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.member.repository.MemberRepository;
+import com.assu.server.domain.partner.entity.Partner;
+import com.assu.server.domain.store.repository.StoreRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import com.assu.server.infra.s3.AmazonS3Manager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BackofficeMemberServiceImpl implements BackofficeMemberService {
+
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
+    private final WithdrawalService withdrawalService;
+    private final AmazonS3Manager amazonS3Manager;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<BackofficeMemberSummaryDTO> listMembers(
+            UserRole role,
+            ActivationStatus status,
+            Boolean deleted,
+            Pageable pageable
+    ) {
+        Page<Member> page = memberRepository.searchMemberSummaries(role, status, deleted, pageable);
+        Map<Long, Member> membersWithProfiles = loadProfilesForSummaries(page.getContent());
+        return PageResponseDTO.of(page.map(member -> BackofficeMemberSummaryDTO.from(
+                membersWithProfiles.getOrDefault(member.getId(), member)
+        )));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<BackofficeMemberSummaryDTO> listDeletedMembers(Pageable pageable) {
+        return listMembers(null, null, true, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BackofficeMemberDetailDTO getMemberDetail(Long memberId) {
+        Member member = findMemberWithRoleProfile(memberId);
+        return toMemberDetail(member);
+    }
+
+    @Override
+    public BackofficeMemberSummaryDTO approveMember(Long memberId) {
+        Member member = findMemberWithRoleProfile(memberId);
+        assertApprovalTarget(member);
+        assertPendingApproval(member);
+
+        member.setIsActivated(ActivationStatus.ACTIVE);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (member.getRole() == UserRole.PARTNER) {
+            Partner partner = member.getPartnerProfile();
+            partner.setIsLicenseVerified(true);
+            partner.setLicenseVerifiedAt(now);
+            activatePartnerStore(partner);
+        } else {
+            Admin admin = member.getAdminProfile();
+            admin.setIsSignVerified(true);
+            admin.setSignVerifiedAt(now);
+        }
+
+        return BackofficeMemberSummaryDTO.from(member);
+    }
+
+    @Override
+    public BackofficeMemberSummaryDTO rejectMember(Long memberId) {
+        Member member = findMemberWithRoleProfile(memberId);
+        assertApprovalTarget(member);
+        assertPendingApproval(member);
+
+        member.setIsActivated(ActivationStatus.INACTIVE);
+        return BackofficeMemberSummaryDTO.from(member);
+    }
+
+    @Override
+    public void forceWithdrawMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+        if (member.getRole() == UserRole.BACKOFFICE) {
+            throw new CustomAuthException(ErrorStatus.CANNOT_WITHDRAW_BACKOFFICE_MEMBER);
+        }
+        withdrawalService.withdrawMember(memberId);
+    }
+
+    @Override
+    public BackofficeMemberSummaryDTO restoreMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+        assertNotBackofficeOperator(member);
+
+        if (member.getDeletedAt() == null) {
+            throw new CustomAuthException(ErrorStatus.MEMBER_NOT_DELETED);
+        }
+
+        member.setDeletedAt(null);
+        return BackofficeMemberSummaryDTO.from(loadProfileForSummary(member));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BackofficeDocumentUrlResponseDTO getPartnerLicenseUrl(Long memberId) {
+        Partner partner = findPartner(memberId);
+        if (partner.getLicenseUrl() == null || partner.getLicenseUrl().isBlank()) {
+            throw new CustomAuthException(ErrorStatus.LICENSE_NOT_FOUND);
+        }
+        String url = amazonS3Manager.generatePresignedUrl(partner.getLicenseUrl());
+        if (url == null || url.isBlank()) {
+            throw new CustomAuthException(ErrorStatus.LICENSE_NOT_FOUND);
+        }
+        return BackofficeDocumentUrlResponseDTO.of(url);
+    }
+
+    @Override
+    public BackofficeMemberSummaryDTO verifyPartnerLicense(Long memberId) {
+        Member member = findMemberWithRoleProfile(memberId);
+        Partner partner = findPartnerProfile(member);
+
+        if (partner.getLicenseUrl() == null || partner.getLicenseUrl().isBlank()) {
+            throw new CustomAuthException(ErrorStatus.LICENSE_NOT_FOUND);
+        }
+
+        partner.setIsLicenseVerified(true);
+        partner.setLicenseVerifiedAt(LocalDateTime.now());
+        return BackofficeMemberSummaryDTO.from(member);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BackofficeDocumentUrlResponseDTO getAdminSignImageUrl(Long memberId) {
+        Admin admin = findAdmin(memberId);
+        if (admin.getSignImageUrl() == null || admin.getSignImageUrl().isBlank()) {
+            throw new CustomAuthException(ErrorStatus.SIGN_IMAGE_NOT_FOUND);
+        }
+        String url = amazonS3Manager.generatePresignedUrl(admin.getSignImageUrl());
+        if (url == null || url.isBlank()) {
+            throw new CustomAuthException(ErrorStatus.SIGN_IMAGE_NOT_FOUND);
+        }
+        return BackofficeDocumentUrlResponseDTO.of(url);
+    }
+
+    private Member findMemberWithRoleProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+        assertNotBackofficeOperator(member);
+
+        return switch (member.getRole()) {
+            case STUDENT -> memberRepository.findStudentWithProfileById(memberId)
+                    .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+            case ADMIN -> memberRepository.findAdminWithProfileById(memberId)
+                    .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+            case PARTNER -> memberRepository.findPartnerWithProfileById(memberId)
+                    .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER));
+            case BACKOFFICE -> throw new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER);
+        };
+    }
+
+    private Map<Long, Member> loadProfilesForSummaries(List<Member> members) {
+        if (members.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, Member> enriched = new HashMap<>();
+
+        List<Long> studentIds = members.stream()
+                .filter(member -> member.getRole() == UserRole.STUDENT)
+                .map(Member::getId)
+                .toList();
+        if (!studentIds.isEmpty()) {
+            putAllById(enriched, memberRepository.findStudentsWithProfileByIdIn(studentIds));
+        }
+
+        List<Long> adminIds = members.stream()
+                .filter(member -> member.getRole() == UserRole.ADMIN)
+                .map(Member::getId)
+                .toList();
+        if (!adminIds.isEmpty()) {
+            putAllById(enriched, memberRepository.findAdminsWithProfileByIdIn(adminIds));
+        }
+
+        List<Long> partnerIds = members.stream()
+                .filter(member -> member.getRole() == UserRole.PARTNER)
+                .map(Member::getId)
+                .toList();
+        if (!partnerIds.isEmpty()) {
+            putAllById(enriched, memberRepository.findPartnersWithProfileByIdIn(partnerIds));
+        }
+
+        return enriched;
+    }
+
+    private Member loadProfileForSummary(Member member) {
+        return loadProfilesForSummaries(List.of(member)).getOrDefault(member.getId(), member);
+    }
+
+    private void putAllById(Map<Long, Member> target, List<Member> members) {
+        target.putAll(members.stream().collect(Collectors.toMap(Member::getId, Function.identity())));
+    }
+
+    private BackofficeMemberDetailDTO toMemberDetail(Member member) {
+        return switch (member.getRole()) {
+            case STUDENT -> BackofficeMemberDetailDTO.fromStudent(member);
+            case ADMIN -> BackofficeMemberDetailDTO.fromAdmin(member);
+            case PARTNER -> BackofficeMemberDetailDTO.fromPartner(member);
+            case BACKOFFICE -> throw new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER);
+        };
+    }
+
+    private Partner findPartner(Long memberId) {
+        Member member = memberRepository.findPartnerWithProfileById(memberId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_PARTNER));
+        return findPartnerProfile(member);
+    }
+
+    private Partner findPartnerProfile(Member member) {
+        if (member.getRole() != UserRole.PARTNER || member.getPartnerProfile() == null) {
+            throw new CustomAuthException(ErrorStatus.NO_SUCH_PARTNER);
+        }
+        return member.getPartnerProfile();
+    }
+
+    private Admin findAdmin(Long memberId) {
+        Member member = memberRepository.findAdminWithProfileById(memberId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_ADMIN));
+        if (member.getAdminProfile() == null) {
+            throw new CustomAuthException(ErrorStatus.NO_SUCH_ADMIN);
+        }
+        return member.getAdminProfile();
+    }
+
+    private void assertNotBackofficeOperator(Member member) {
+        if (member.getRole() == UserRole.BACKOFFICE) {
+            throw new CustomAuthException(ErrorStatus.NO_SUCH_MEMBER);
+        }
+    }
+
+    private void assertApprovalTarget(Member member) {
+        if (member.getRole() != UserRole.ADMIN && member.getRole() != UserRole.PARTNER) {
+            throw new CustomAuthException(ErrorStatus.MEMBER_APPROVAL_NOT_SUPPORTED);
+        }
+        if (member.getDeletedAt() != null) {
+            throw new CustomAuthException(ErrorStatus.MEMBER_ALREADY_WITHDRAWN);
+        }
+    }
+
+    private void assertPendingApproval(Member member) {
+        if (member.getIsActivated() != ActivationStatus.SUSPEND) {
+            throw new CustomAuthException(ErrorStatus.MEMBER_NOT_PENDING_APPROVAL);
+        }
+    }
+
+    private void activatePartnerStore(Partner partner) {
+        storeRepository.findByPartner(partner).ifPresent(store -> {
+            store.setIsActivate(ActivationStatus.ACTIVE);
+        });
+    }
+}

--- a/src/main/java/com/assu/server/domain/chat/dto/BlockResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/chat/dto/BlockResponseDTO.java
@@ -1,7 +1,6 @@
 package com.assu.server.domain.chat.dto;
 
 import com.assu.server.domain.chat.entity.Block;
-import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
 
 import java.time.LocalDateTime;
@@ -30,17 +29,10 @@ public class BlockResponseDTO {
                 Block block
         ) {
             Member blockedMember = block.getBlocked();
-            UserRole blockedRole = blockedMember.getRole();
-            String blockedName;
-            if (blockedRole == UserRole.ADMIN) {
-                blockedName = blockedMember.getAdminProfile().getName();
-            } else {
-                blockedName = blockedMember.getPartnerProfile().getName();
-            }
 
             return new BlockMemberDTO(
                     blockedMember.getId(),
-                    blockedName,
+                    blockedMember.resolveName(),
                     block.getCreatedAt()
             );
         }

--- a/src/main/java/com/assu/server/domain/chat/service/BlockServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/chat/service/BlockServiceImpl.java
@@ -39,15 +39,7 @@ public class BlockServiceImpl implements BlockService {
             return null;
         }
 
-        UserRole blockedRole = blocked.getRole();
-        String blockedName;
-        if (blockedRole == UserRole.ADMIN) {
-            blockedName = blocked.getAdminProfile().getName();
-        } else if (blockedRole == UserRole.PARTNER) {
-            blockedName = blocked.getPartnerProfile().getName();
-        } else {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST);
-        }
+        String blockedName = resolveBlockedName(blocked);
 
         Block block = Block.builder()
                 .blocker(blocker)
@@ -67,15 +59,7 @@ public class BlockServiceImpl implements BlockService {
         Member blocked = memberRepository.findById(blockedId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
 
-        UserRole blockedRole = blocked.getRole();
-        String blockedName;
-        if (blockedRole == UserRole.ADMIN) {
-            blockedName = blocked.getAdminProfile().getName();
-        } else if (blockedRole == UserRole.PARTNER) {
-            blockedName = blocked.getPartnerProfile().getName();
-        } else {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST);
-        }
+        String blockedName = resolveBlockedName(blocked);
 
         if (blockRepository.existsBlockRelationBetween(blocker, blocked)) {
             return BlockResponseDTO.CheckBlockMemberDTO.of(blockedId, blockedName, true);
@@ -93,15 +77,7 @@ public class BlockServiceImpl implements BlockService {
         Member blocked = memberRepository.findById(blockedId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));
 
-        UserRole blockedRole = blocked.getRole();
-        String blockedName;
-        if (blockedRole == UserRole.ADMIN) {
-            blockedName = blocked.getAdminProfile().getName();
-        } else if (blockedRole == UserRole.PARTNER) {
-            blockedName = blocked.getPartnerProfile().getName();
-        } else {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST);
-        }
+        String blockedName = resolveBlockedName(blocked);
 
         // Transactional 환경에서는 Dirty-checking으로 delete 쿼리가 나갑니다.
         blockRepository.deleteByBlockerAndBlocked(blocker, blocked);
@@ -117,5 +93,14 @@ public class BlockServiceImpl implements BlockService {
         List<Block> blockList = blockRepository.findByBlocker(blocker);
 
         return BlockResponseDTO.BlockMemberDTO.fromList(blockList);
+    }
+
+    // 차단 대상은 ADMIN/PARTNER만 허용
+    private String resolveBlockedName(Member blocked) {
+        UserRole blockedRole = blocked.getRole();
+        if (blockedRole != UserRole.ADMIN && blockedRole != UserRole.PARTNER) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        return blocked.resolveName();
     }
 }

--- a/src/main/java/com/assu/server/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/chat/service/ChatServiceImpl.java
@@ -8,7 +8,6 @@ import com.assu.server.domain.chat.entity.Message;
 import com.assu.server.domain.chat.repository.ChatRepository;
 import com.assu.server.domain.chat.repository.MessageRepository;
 import com.assu.server.domain.common.enums.ActivationStatus;
-import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.member.repository.MemberRepository;
 import com.assu.server.domain.notification.service.NotificationCommandService;
@@ -150,12 +149,7 @@ public class ChatServiceImpl implements ChatService {
             );
 
             // 4-3. 발신자 이름 찾기 (기존 컨트롤러 로직)
-            String senderName;
-            if (sender.getRole() == UserRole.ADMIN) { // 이미 sender 객체가 있으므로 재활용
-                senderName = sender.getAdminProfile().getName();
-            } else {
-                senderName = sender.getPartnerProfile().getName();
-            }
+            String senderName = sender.resolveName();
 
             // 4-4. 알림 전송
             notificationCommandService.sendChat(request.receiverId(), request.roomId(), senderName, request.message());

--- a/src/main/java/com/assu/server/domain/member/entity/Member.java
+++ b/src/main/java/com/assu/server/domain/member/entity/Member.java
@@ -75,6 +75,16 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private CommonAuth commonAuth;
 
+    // 역할별 프로필에서 이름(이름/업체명/단체명)을 반환
+    public String resolveName() {
+        return switch (role) {
+            case STUDENT -> studentProfile != null ? studentProfile.getName() : null;
+            case ADMIN -> adminProfile != null ? adminProfile.getName() : null;
+            case PARTNER -> partnerProfile != null ? partnerProfile.getName() : null;
+            case BACKOFFICE -> backofficeProfile != null ? backofficeProfile.getName() : null;
+        };
+    }
+
     public void setProfile(Object profile) {
         if (profile instanceof Student s) {
             this.studentProfile = s;

--- a/src/main/java/com/assu/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/assu/server/domain/member/repository/MemberRepository.java
@@ -1,15 +1,107 @@
 package com.assu.server.domain.member.repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
 import com.assu.server.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberById(Long id);
     List<Member> findByDeletedAtBefore(LocalDateTime deletedAt);
+
+    @Query(
+            value = """
+                    SELECT m FROM Member m
+                    WHERE m.role <> com.assu.server.domain.common.enums.UserRole.BACKOFFICE
+                      AND (:role IS NULL OR m.role = :role)
+                      AND (:status IS NULL OR m.isActivated = :status)
+                      AND (
+                        :deletedFilter IS NULL
+                        OR (:deletedFilter = TRUE AND m.deletedAt IS NOT NULL)
+                        OR (:deletedFilter = FALSE AND m.deletedAt IS NULL)
+                      )
+                    """,
+            countQuery = """
+                    SELECT COUNT(m) FROM Member m
+                    WHERE m.role <> com.assu.server.domain.common.enums.UserRole.BACKOFFICE
+                      AND (:role IS NULL OR m.role = :role)
+                      AND (:status IS NULL OR m.isActivated = :status)
+                      AND (
+                        :deletedFilter IS NULL
+                        OR (:deletedFilter = TRUE AND m.deletedAt IS NOT NULL)
+                        OR (:deletedFilter = FALSE AND m.deletedAt IS NULL)
+                      )
+                    """
+    )
+    Page<Member> searchMemberSummaries(
+            @Param("role") UserRole role,
+            @Param("status") ActivationStatus status,
+            @Param("deletedFilter") Boolean deletedFilter,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT m FROM Member m
+            JOIN FETCH m.ssuAuth
+            JOIN FETCH m.studentProfile
+            WHERE m.id = :id
+              AND m.role = com.assu.server.domain.common.enums.UserRole.STUDENT
+            """)
+    Optional<Member> findStudentWithProfileById(@Param("id") Long id);
+
+    @Query("""
+            SELECT m FROM Member m
+            LEFT JOIN FETCH m.commonAuth
+            JOIN FETCH m.adminProfile
+            WHERE m.id = :id
+              AND m.role = com.assu.server.domain.common.enums.UserRole.ADMIN
+            """)
+    Optional<Member> findAdminWithProfileById(@Param("id") Long id);
+
+    @Query("""
+            SELECT m FROM Member m
+            LEFT JOIN FETCH m.commonAuth
+            JOIN FETCH m.partnerProfile
+            WHERE m.id = :id
+              AND m.role = com.assu.server.domain.common.enums.UserRole.PARTNER
+            """)
+    Optional<Member> findPartnerWithProfileById(@Param("id") Long id);
+
+    @Query("""
+            SELECT DISTINCT m FROM Member m
+            JOIN FETCH m.ssuAuth
+            JOIN FETCH m.studentProfile
+            WHERE m.id IN :ids
+              AND m.role = com.assu.server.domain.common.enums.UserRole.STUDENT
+            """)
+    List<Member> findStudentsWithProfileByIdIn(@Param("ids") Collection<Long> ids);
+
+    @Query("""
+            SELECT DISTINCT m FROM Member m
+            LEFT JOIN FETCH m.commonAuth
+            JOIN FETCH m.adminProfile
+            WHERE m.id IN :ids
+              AND m.role = com.assu.server.domain.common.enums.UserRole.ADMIN
+            """)
+    List<Member> findAdminsWithProfileByIdIn(@Param("ids") Collection<Long> ids);
+
+    @Query("""
+            SELECT DISTINCT m FROM Member m
+            LEFT JOIN FETCH m.commonAuth
+            JOIN FETCH m.partnerProfile
+            WHERE m.id IN :ids
+              AND m.role = com.assu.server.domain.common.enums.UserRole.PARTNER
+            """)
+    List<Member> findPartnersWithProfileByIdIn(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
@@ -54,6 +54,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_SUCH_PARTNER(HttpStatus.NOT_FOUND,"MEMBER_4003","존재하지 않는 partner ID 입니다."),
     NO_SUCH_STUDENT(HttpStatus.NOT_FOUND,"MEMBER_4004","존재하지 않는 student ID 입니다."),
     NO_SUCH_STORE(HttpStatus.NOT_FOUND, "STORE_4006", "존재하지 않는 스토어 ID입니다."),
+    PARTNER_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_4007", "파트너에 연결된 스토어가 없습니다."),
     NO_SUCH_USAGE(HttpStatus.NOT_FOUND, "USAGE4001", "존재하지 않는 제휴 사용 내역입니다."),
     NO_PAPER_FOR_STORE(HttpStatus.NOT_FOUND, "ADMIN_4005", "존재하지 않는 paper ID입니다."),
     NO_AVAILABLE_PARTNER(HttpStatus.NOT_FOUND, "MEMBER_4009", "제휴업체를 찾을 수 없습니다."),
@@ -63,13 +64,13 @@ public enum ErrorStatus implements BaseErrorCode {
     EXISTED_STUDENT(HttpStatus.CONFLICT,"MEMBER_4009","이미 존재하는 학번입니다."),
 
     MEMBER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "MEMBER_4010", "이미 탈퇴된 회원입니다."),
-    MEMBER_NOT_PENDING_APPROVAL(HttpStatus.BAD_REQUEST, "MEMBER_4012", "승인 대기 상태가 아닌 회원입니다."),
-    CANNOT_WITHDRAW_BACKOFFICE_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_4013", "백오피스 운영자는 강제 탈퇴할 수 없습니다."),
-    MEMBER_NOT_DELETED(HttpStatus.BAD_REQUEST, "MEMBER_4014", "탈퇴 상태가 아닌 회원입니다."),
-    LICENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4015", "사업자등록증 파일이 없습니다."),
-    SIGN_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4016", "인감 이미지 파일이 없습니다."),
-    MEMBER_APPROVAL_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "MEMBER_4017", "승인/거절 대상이 아닌 회원 역할입니다."),
-    MEMBER_PENDING_APPROVAL(HttpStatus.FORBIDDEN, "MEMBER_4018", "가입 승인 대기 중입니다. 백오피스 승인 후 로그인할 수 있습니다."),
+    MEMBER_NOT_PENDING_APPROVAL(HttpStatus.BAD_REQUEST, "MEMBER_4011", "승인 대기 상태가 아닌 회원입니다."),
+    CANNOT_WITHDRAW_BACKOFFICE_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_4012", "백오피스 운영자는 강제 탈퇴할 수 없습니다."),
+    MEMBER_NOT_DELETED(HttpStatus.BAD_REQUEST, "MEMBER_4013", "탈퇴 상태가 아닌 회원입니다."),
+    LICENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4014", "사업자등록증 파일이 없습니다."),
+    SIGN_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4015", "인감 이미지 파일이 없습니다."),
+    MEMBER_APPROVAL_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "MEMBER_4016", "승인/거절 대상이 아닌 회원 역할입니다."),
+    MEMBER_PENDING_APPROVAL(HttpStatus.FORBIDDEN, "MEMBER_4017", "가입 승인 대기 중입니다. 백오피스 승인 후 로그인할 수 있습니다."),
 
     // 제휴 에러
     NO_SUCH_PAPER(HttpStatus.NOT_FOUND, "PAPER_9001", "제휴를 찾을 수 없습니다."),

--- a/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,13 @@ public enum ErrorStatus implements BaseErrorCode {
     EXISTED_STUDENT(HttpStatus.CONFLICT,"MEMBER_4009","이미 존재하는 학번입니다."),
 
     MEMBER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "MEMBER_4010", "이미 탈퇴된 회원입니다."),
+    MEMBER_NOT_PENDING_APPROVAL(HttpStatus.BAD_REQUEST, "MEMBER_4012", "승인 대기 상태가 아닌 회원입니다."),
+    CANNOT_WITHDRAW_BACKOFFICE_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_4013", "백오피스 운영자는 강제 탈퇴할 수 없습니다."),
+    MEMBER_NOT_DELETED(HttpStatus.BAD_REQUEST, "MEMBER_4014", "탈퇴 상태가 아닌 회원입니다."),
+    LICENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4015", "사업자등록증 파일이 없습니다."),
+    SIGN_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4016", "인감 이미지 파일이 없습니다."),
+    MEMBER_APPROVAL_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "MEMBER_4017", "승인/거절 대상이 아닌 회원 역할입니다."),
+    MEMBER_PENDING_APPROVAL(HttpStatus.FORBIDDEN, "MEMBER_4018", "가입 승인 대기 중입니다. 백오피스 승인 후 로그인할 수 있습니다."),
 
     // 제휴 에러
     NO_SUCH_PAPER(HttpStatus.NOT_FOUND, "PAPER_9001", "제휴를 찾을 수 없습니다."),

--- a/src/test/java/com/assu/server/backoffice/BackofficeMemberServiceTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficeMemberServiceTest.java
@@ -10,6 +10,8 @@ import com.assu.server.domain.member.entity.Member;
 import com.assu.server.domain.member.repository.MemberRepository;
 import com.assu.server.domain.partner.entity.Partner;
 import com.assu.server.domain.partner.repository.PartnerRepository;
+import com.assu.server.domain.store.entity.Store;
+import com.assu.server.domain.store.repository.StoreRepository;
 import com.assu.server.global.apiPayload.code.status.ErrorStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,9 @@ class BackofficeMemberServiceTest {
     @Autowired
     private WithdrawalService withdrawalService;
 
+    @Autowired
+    private StoreRepository storeRepository;
+
     @Test
     @DisplayName("SUSPEND Partner 회원을 승인하면 ACTIVE 및 license verified 처리")
     void approvePartnerMember() {
@@ -54,6 +59,9 @@ class BackofficeMemberServiceTest {
         assertThat(updated.getIsActivated()).isEqualTo(ActivationStatus.ACTIVE);
         assertThat(updated.getPartnerProfile().getIsLicenseVerified()).isTrue();
         assertThat(updated.getPartnerProfile().getLicenseVerifiedAt()).isNotNull();
+
+        Store store = storeRepository.findByPartner(updated.getPartnerProfile()).orElseThrow();
+        assertThat(store.getIsActivate()).isEqualTo(ActivationStatus.ACTIVE);
     }
 
     @Test
@@ -83,6 +91,19 @@ class BackofficeMemberServiceTest {
         assertThat(result.deletedAt()).isNull();
         Member updated = memberRepository.findById(member.getId()).orElseThrow();
         assertThat(updated.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("거절(INACTIVE)된 회원도 다시 승인하면 ACTIVE가 된다")
+    void approveRejectedMember() {
+        Member member = createPartnerMember(ActivationStatus.INACTIVE);
+
+        BackofficeMemberSummaryDTO result = backofficeMemberService.approveMember(member.getId());
+
+        assertThat(result.status()).isEqualTo(ActivationStatus.ACTIVE);
+        Member updated = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(updated.getIsActivated()).isEqualTo(ActivationStatus.ACTIVE);
+        assertThat(updated.getPartnerProfile().getIsLicenseVerified()).isTrue();
     }
 
     @Test
@@ -116,6 +137,18 @@ class BackofficeMemberServiceTest {
                 .longitude(127.0)
                 .build());
         member.setPartnerProfile(partner);
+
+        storeRepository.save(Store.builder()
+                .partner(partner)
+                .rate(0)
+                .isActivate(ActivationStatus.SUSPEND)
+                .name("Test Store")
+                .address("Seoul")
+                .detailAddress("Detail")
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
+
         return memberRepository.save(member);
     }
 }

--- a/src/test/java/com/assu/server/backoffice/BackofficeMemberServiceTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficeMemberServiceTest.java
@@ -1,0 +1,121 @@
+package com.assu.server.backoffice;
+
+import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.domain.auth.service.WithdrawalService;
+import com.assu.server.domain.backoffice.dto.BackofficeMemberSummaryDTO;
+import com.assu.server.domain.backoffice.service.BackofficeMemberService;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.member.repository.MemberRepository;
+import com.assu.server.domain.partner.entity.Partner;
+import com.assu.server.domain.partner.repository.PartnerRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@Import(BackofficeSecurityIntegrationTest.TestJwtConfig.class)
+class BackofficeMemberServiceTest {
+
+    @Autowired
+    private BackofficeMemberService backofficeMemberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PartnerRepository partnerRepository;
+
+    @Autowired
+    private WithdrawalService withdrawalService;
+
+    @Test
+    @DisplayName("SUSPEND Partner 회원을 승인하면 ACTIVE 및 license verified 처리")
+    void approvePartnerMember() {
+        Member member = createPartnerMember(ActivationStatus.SUSPEND);
+
+        BackofficeMemberSummaryDTO result = backofficeMemberService.approveMember(member.getId());
+
+        assertThat(result.status()).isEqualTo(ActivationStatus.ACTIVE);
+        assertThat(result.isLicenseVerified()).isTrue();
+
+        Member updated = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(updated.getIsActivated()).isEqualTo(ActivationStatus.ACTIVE);
+        assertThat(updated.getPartnerProfile().getIsLicenseVerified()).isTrue();
+        assertThat(updated.getPartnerProfile().getLicenseVerifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BACKOFFICE 회원은 강제 탈퇴할 수 없다")
+    void cannotForceWithdrawBackofficeMember() {
+        Member member = memberRepository.save(Member.builder()
+                .role(UserRole.BACKOFFICE)
+                .isActivated(ActivationStatus.ACTIVE)
+                .isLocationTermAgreed(true)
+                .isMarketingTermAgreed(false)
+                .build());
+
+        assertThatThrownBy(() -> backofficeMemberService.forceWithdrawMember(member.getId()))
+                .isInstanceOf(CustomAuthException.class)
+                .extracting(ex -> ((CustomAuthException) ex).getCode())
+                .isEqualTo(ErrorStatus.CANNOT_WITHDRAW_BACKOFFICE_MEMBER);
+    }
+
+    @Test
+    @DisplayName("탈퇴 회원을 복구하면 deletedAt이 null이 된다")
+    void restoreDeletedMember() {
+        Member member = createPartnerMember(ActivationStatus.ACTIVE);
+        withdrawalService.withdrawMember(member.getId());
+
+        BackofficeMemberSummaryDTO result = backofficeMemberService.restoreMember(member.getId());
+
+        assertThat(result.deletedAt()).isNull();
+        Member updated = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(updated.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 회원은 승인할 수 없다")
+    void cannotApproveActiveMember() {
+        Member member = createPartnerMember(ActivationStatus.ACTIVE);
+
+        assertThatThrownBy(() -> backofficeMemberService.approveMember(member.getId()))
+                .isInstanceOf(CustomAuthException.class)
+                .extracting(ex -> ((CustomAuthException) ex).getCode())
+                .isEqualTo(ErrorStatus.MEMBER_NOT_PENDING_APPROVAL);
+    }
+
+    private Member createPartnerMember(ActivationStatus status) {
+        Member member = memberRepository.save(Member.builder()
+                .role(UserRole.PARTNER)
+                .isActivated(status)
+                .isLocationTermAgreed(true)
+                .isMarketingTermAgreed(false)
+                .build());
+
+        Partner partner = partnerRepository.save(Partner.builder()
+                .member(member)
+                .name("Test Partner")
+                .phoneNum("01012345678")
+                .isPhoneVerified(true)
+                .address("Seoul")
+                .detailAddress("Detail")
+                .licenseUrl("partners/1/license.png")
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
+        member.setPartnerProfile(partner);
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/com/assu/server/backoffice/BackofficeSecurityIntegrationTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficeSecurityIntegrationTest.java
@@ -251,7 +251,7 @@ class BackofficeSecurityIntegrationTest {
                                 {"email":"pending@test.com","password":"password123"}
                                 """))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("MEMBER_4018"))
+                .andExpect(jsonPath("$.code").value("MEMBER_4017"))
                 .andExpect(jsonPath("$.message").value(ErrorStatus.MEMBER_PENDING_APPROVAL.getMessage()));
     }
 

--- a/src/test/java/com/assu/server/backoffice/BackofficeSecurityIntegrationTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficeSecurityIntegrationTest.java
@@ -18,6 +18,8 @@ import com.assu.server.domain.member.repository.MemberRepository;
 import com.assu.server.domain.student.entity.Student;
 import com.assu.server.domain.student.service.StudentServiceImpl;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.assu.server.domain.partner.entity.Partner;
+import com.assu.server.domain.partner.repository.PartnerRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,8 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -47,7 +51,10 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -70,6 +77,12 @@ class BackofficeSecurityIntegrationTest {
 
     @Autowired
     private BackofficeUserRepository backofficeUserRepository;
+
+    @Autowired
+    private PartnerRepository partnerRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Autowired
     private BackofficeAuditLogRepository backofficeAuditLogRepository;
@@ -151,6 +164,173 @@ class BackofficeSecurityIntegrationTest {
                 .isEqualTo(ErrorStatus.JWT_AUDIENCE_MISMATCH);
 
         assertThat(backofficeAuditLogRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("BACKOFFICE 토큰으로 Partner 회원 승인 및 감사 로그 기록")
+    void backofficeTokenCanApprovePartnerMember() throws Exception {
+        Member backofficeMember = createBackofficeMember("operator@test.com", "Operator");
+        Member partnerMember = createPartnerMember("partner@test.com", ActivationStatus.SUSPEND);
+        String accessToken = jwtUtil.issueBackofficeTokens(
+                backofficeMember.getId(),
+                "operator@test.com",
+                UserRole.BACKOFFICE,
+                AuthRealm.COMMON.name()
+        ).accessToken();
+
+        mockMvc.perform(patch("/backoffice/members/{memberId}/approve", partnerMember.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        Member updated = memberRepository.findById(partnerMember.getId()).orElseThrow();
+        assertThat(updated.getIsActivated()).isEqualTo(ActivationStatus.ACTIVE);
+
+        assertThat(backofficeAuditLogRepository.findAll())
+                .singleElement()
+                .satisfies(log -> {
+                    assertThat(log.getAction()).isEqualTo("MEMBER_APPROVE");
+                    assertThat(log.getTargetResourceId()).isEqualTo(String.valueOf(partnerMember.getId()));
+                    assertThat(log.getBackofficeMemberId()).isEqualTo(backofficeMember.getId());
+                });
+    }
+
+    @Test
+    @DisplayName("STUDENT 앱 토큰으로 회원 승인 API 접근 거부")
+    void studentTokenCannotApproveMember() throws Exception {
+        Member student = createStudentMember("student2@test.com");
+        Member partnerMember = createPartnerMember("partner2@test.com", ActivationStatus.SUSPEND);
+        String accessToken = jwtUtil.issueTokens(
+                student.getId(),
+                "student2@test.com",
+                UserRole.STUDENT,
+                AuthRealm.COMMON.name()
+        ).accessToken();
+
+        assertThatThrownBy(() -> mockMvc.perform(patch("/backoffice/members/{memberId}/approve", partnerMember.getId())
+                        .header("Authorization", "Bearer " + accessToken)))
+                .isInstanceOf(CustomAuthException.class)
+                .extracting(ex -> ((CustomAuthException) ex).getCode())
+                .isEqualTo(ErrorStatus.JWT_AUDIENCE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("BACKOFFICE 토큰으로 탈퇴 회원 복구 및 감사 로그 기록")
+    void backofficeTokenCanRestoreDeletedMember() throws Exception {
+        Member backofficeMember = createBackofficeMember("operator2@test.com", "Operator2");
+        Member partnerMember = createPartnerMember("partner3@test.com", ActivationStatus.ACTIVE);
+        partnerMember.setDeletedAt(LocalDateTime.now());
+        memberRepository.save(partnerMember);
+
+        String accessToken = jwtUtil.issueBackofficeTokens(
+                backofficeMember.getId(),
+                "operator2@test.com",
+                UserRole.BACKOFFICE,
+                AuthRealm.COMMON.name()
+        ).accessToken();
+
+        mockMvc.perform(patch("/backoffice/members/{memberId}/restore", partnerMember.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        Member updated = memberRepository.findById(partnerMember.getId()).orElseThrow();
+        assertThat(updated.getDeletedAt()).isNull();
+
+        assertThat(backofficeAuditLogRepository.findAll())
+                .singleElement()
+                .satisfies(log -> assertThat(log.getAction()).isEqualTo("MEMBER_RESTORE"));
+    }
+
+    @Test
+    @DisplayName("SUSPEND Partner는 공통 로그인 시 승인 대기 에러 반환")
+    void suspendPartnerCannotLoginCommon() throws Exception {
+        createPartnerMemberWithPassword("pending@test.com", ActivationStatus.SUSPEND, "password123");
+
+        mockMvc.perform(post("/auth/commons/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"pending@test.com","password":"password123"}
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("MEMBER_4018"))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.MEMBER_PENDING_APPROVAL.getMessage()));
+    }
+
+    @Test
+    @DisplayName("BACKOFFICE 토큰으로 회원 목록 조회 가능")
+    void backofficeTokenCanListMembers() throws Exception {
+        Member backofficeMember = createBackofficeMember("operator3@test.com", "Operator3");
+        createPartnerMember("partner4@test.com", ActivationStatus.SUSPEND);
+        String accessToken = jwtUtil.issueBackofficeTokens(
+                backofficeMember.getId(),
+                "operator3@test.com",
+                UserRole.BACKOFFICE,
+                AuthRealm.COMMON.name()
+        ).accessToken();
+
+        mockMvc.perform(get("/backoffice/members")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+    }
+
+    private Member createPartnerMember(String email, ActivationStatus status) {
+        Member member = memberRepository.save(Member.builder()
+                .role(UserRole.PARTNER)
+                .isActivated(status)
+                .isLocationTermAgreed(true)
+                .isMarketingTermAgreed(false)
+                .build());
+
+        commonAuthRepository.save(CommonAuth.builder()
+                .member(member)
+                .email(email)
+                .hashedPassword("hashed-password")
+                .lastLoginAt(LocalDateTime.now())
+                .build());
+
+        Partner partner = partnerRepository.save(Partner.builder()
+                .member(member)
+                .name("Partner " + email)
+                .phoneNum("01099998888")
+                .isPhoneVerified(true)
+                .address("Seoul")
+                .detailAddress("Detail")
+                .licenseUrl("partners/" + member.getId() + "/license.png")
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
+        member.setPartnerProfile(partner);
+
+        return memberRepository.save(member);
+    }
+
+    private void createPartnerMemberWithPassword(String email, ActivationStatus status, String rawPassword) {
+        Member member = memberRepository.save(Member.builder()
+                .role(UserRole.PARTNER)
+                .isActivated(status)
+                .isLocationTermAgreed(true)
+                .isMarketingTermAgreed(false)
+                .build());
+
+        commonAuthRepository.save(CommonAuth.builder()
+                .member(member)
+                .email(email)
+                .hashedPassword(passwordEncoder.encode(rawPassword))
+                .lastLoginAt(LocalDateTime.now())
+                .build());
+
+        Partner partner = partnerRepository.save(Partner.builder()
+                .member(member)
+                .name("Partner " + email)
+                .phoneNum("01088887777")
+                .isPhoneVerified(true)
+                .address("Seoul")
+                .detailAddress("Detail")
+                .licenseUrl("partners/" + member.getId() + "/license.png")
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
+        member.setPartnerProfile(partner);
+        memberRepository.save(member);
     }
 
     private Member createBackofficeMember(String email, String name) {

--- a/src/test/java/com/assu/server/backoffice/BackofficeSecurityIntegrationTest.java
+++ b/src/test/java/com/assu/server/backoffice/BackofficeSecurityIntegrationTest.java
@@ -20,6 +20,8 @@ import com.assu.server.domain.student.service.StudentServiceImpl;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.assu.server.domain.partner.entity.Partner;
 import com.assu.server.domain.partner.repository.PartnerRepository;
+import com.assu.server.domain.store.entity.Store;
+import com.assu.server.domain.store.repository.StoreRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -80,6 +82,9 @@ class BackofficeSecurityIntegrationTest {
 
     @Autowired
     private PartnerRepository partnerRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -300,6 +305,17 @@ class BackofficeSecurityIntegrationTest {
                 .build());
         member.setPartnerProfile(partner);
 
+        storeRepository.save(Store.builder()
+                .partner(partner)
+                .rate(0)
+                .isActivate(ActivationStatus.SUSPEND)
+                .name("Store " + email)
+                .address("Seoul")
+                .detailAddress("Detail")
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
+
         return memberRepository.save(member);
     }
 
@@ -430,6 +446,11 @@ class BackofficeSecurityIntegrationTest {
         @Bean
         StringRedisTemplate stringRedisTemplate() {
             return Mockito.mock(StringRedisTemplate.class);
+        }
+
+        @Bean
+        ConnectionFactory rabbitConnectionFactory() {
+            return Mockito.mock(ConnectionFactory.class);
         }
 
         @Bean(name = "rabbitListenerContainerFactory")

--- a/src/test/java/com/assu/server/backoffice/LoginServiceSuspendTest.java
+++ b/src/test/java/com/assu/server/backoffice/LoginServiceSuspendTest.java
@@ -1,0 +1,87 @@
+package com.assu.server.backoffice;
+
+import com.assu.server.domain.auth.dto.login.CommonLoginRequestDTO;
+import com.assu.server.domain.auth.entity.CommonAuth;
+import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.domain.auth.repository.CommonAuthRepository;
+import com.assu.server.domain.auth.service.LoginService;
+import com.assu.server.domain.common.enums.ActivationStatus;
+import com.assu.server.domain.common.enums.UserRole;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.member.repository.MemberRepository;
+import com.assu.server.domain.partner.entity.Partner;
+import com.assu.server.domain.partner.repository.PartnerRepository;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@Import(BackofficeSecurityIntegrationTest.TestJwtConfig.class)
+class LoginServiceSuspendTest {
+
+    @Autowired
+    private LoginService loginService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CommonAuthRepository commonAuthRepository;
+
+    @Autowired
+    private PartnerRepository partnerRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("SUSPEND 계정 공통 로그인 시 MEMBER_PENDING_APPROVAL 반환")
+    void suspendAccountReturnsPendingApprovalError() {
+        Member member = memberRepository.save(Member.builder()
+                .role(UserRole.PARTNER)
+                .isActivated(ActivationStatus.SUSPEND)
+                .isLocationTermAgreed(true)
+                .isMarketingTermAgreed(false)
+                .build());
+
+        CommonAuth commonAuth = commonAuthRepository.save(CommonAuth.builder()
+                .member(member)
+                .email("pending-login@test.com")
+                .hashedPassword(passwordEncoder.encode("password123"))
+                .lastLoginAt(LocalDateTime.now())
+                .build());
+        member.setCommonAuth(commonAuth);
+
+        Partner partner = partnerRepository.save(Partner.builder()
+                .member(member)
+                .name("Pending Partner")
+                .phoneNum("01011112222")
+                .isPhoneVerified(true)
+                .address("Seoul")
+                .detailAddress("Detail")
+                .licenseUrl("partners/" + member.getId() + "/license.png")
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
+        member.setPartnerProfile(partner);
+        memberRepository.save(member);
+
+        assertThatThrownBy(() -> loginService.loginCommon(
+                new CommonLoginRequestDTO("pending-login@test.com", "password123")))
+                .isInstanceOf(CustomAuthException.class)
+                .extracting(ex -> ((CustomAuthException) ex).getCode())
+                .isEqualTo(ErrorStatus.MEMBER_PENDING_APPROVAL);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #368 

## 📝작업 내용

백오피스 운영자가 회원을 관리할 수 있는 API 6개 기능을 추가하고, 이에 맞춰 Admin/Partner 가입 플로우를 승인제로 변경했습니다.

### 1. 가입 플로우 변경 (승인제 전환)
- Admin/Partner 가입 시 `isActivated = SUSPEND`로 생성, **JWT 미발급** (`tokens = null`)
- Partner 가입 시 생성되는 Store도 `SUSPEND`로 생성
- `SUSPEND` 계정이 공통 로그인(`POST /auth/commons/login`) 시도 시 전용 에러 반환
  - `MEMBER_4018` (403): "가입 승인 대기 중입니다. 백오피스 승인 후 로그인할 수 있습니다."
  - 비밀번호 검증 **후** 상태를 확인하므로 이메일만으로 승인 대기 여부를 알 수 없음 (계정 열거 방지)

### 2. 백오피스 회원 관리 API (`BackofficeMemberController`)

| Method | Path | Audit Action |
|--------|------|--------------|
| GET | `/backoffice/members` | - |
| GET | `/backoffice/members/deleted` | - |
| GET | `/backoffice/members/{memberId}` | - |
| PATCH | `/backoffice/members/{memberId}/approve` | `MEMBER_APPROVE` |
| PATCH | `/backoffice/members/{memberId}/reject` | `MEMBER_REJECT` |
| PATCH | `/backoffice/members/{memberId}/force-withdraw` | `MEMBER_FORCE_WITHDRAW` |
| PATCH | `/backoffice/members/{memberId}/restore` | `MEMBER_RESTORE` |

- **승인**: `SUSPEND` → `ACTIVE`. Partner는 `isLicenseVerified=true` + Store `ACTIVE` 처리, Admin은 `isSignVerified=true` 동시 처리
- **거절**: `SUSPEND` → `INACTIVE`
- **강제 탈퇴**: 기존 `WithdrawalService` 로직 재사용 (soft delete + refresh token 전체 삭제). BACKOFFICE 운영자는 대상 제외
- **복구**: `deletedAt = null` (isActivated는 유지)
- 목록 조회는 `role` / `status` / `deleted` 필터 + 페이지네이션 지원

### 3. 서류 조회/검증 API

| Method | Path | Audit Action |
|--------|------|--------------|
| GET | `/backoffice/partners/{memberId}/license` | - |
| PATCH | `/backoffice/partners/{memberId}/license/verify` | `PARTNER_LICENSE_VERIFY` |
| GET | `/backoffice/admins/{memberId}/sign-image` | - |

- S3 key → **presigned URL(10분)** 로 변환해 반환
- 사업자등록증 검증은 가입 승인과 **독립적으로** 수행 가능 (승인 전 서류 선검토 플로우 지원)

### 4. 리팩토링
- **`MemberRepository` 쿼리 역할별 분리**
  - 목록: `Member`만 조회 → 역할별 batch 쿼리(`IN` 절)로 프로필 보강 (페이지당 최대 3쿼리)
  - 상세/변경: `findStudentWithProfileById`(ssuAuth+studentProfile), `findAdmin...`(commonAuth+adminProfile), `findPartner...`(commonAuth+partnerProfile)
- **상세 DTO 역할별 분리**: flat 구조 → `base` + `student`/`admin`/`partner` nested 구조
  - `BackofficeMemberBaseDetailDTO` / `BackofficeStudentProfileDetailDTO` / `BackofficeAdminProfileDetailDTO` / `BackofficePartnerProfileDetailDTO`
  - `@JsonInclude(NON_NULL)`로 해당 역할 프로필만 응답에 포함
- **`WithdrawalService.withdrawMember(Long)`** 공개 메서드로 추출 (자진 탈퇴/강제 탈퇴 공통화)

### 5. 기타
- `ErrorStatus` 추가: `MEMBER_NOT_PENDING_APPROVAL`(4012), `CANNOT_WITHDRAW_BACKOFFICE_MEMBER`(4013), `MEMBER_NOT_DELETED`(4014), `LICENSE_NOT_FOUND`(4015), `SIGN_IMAGE_NOT_FOUND`(4016), `MEMBER_APPROVAL_NOT_SUPPORTED`(4017), `MEMBER_PENDING_APPROVAL`(4018)
- 신규/변경 API Swagger `@Operation` 명세 작성 (기존 컨벤션 준수)
- 테스트: `BackofficeMemberServiceTest`(승인/강제탈퇴 가드/복구), `LoginServiceSuspendTest`(SUSPEND 로그인 차단), `BackofficeSecurityIntegrationTest` 확장(RBAC + 감사 로그 insert 검증)

## 🔎코드 설명

**SUSPEND 로그인 차단 위치** — `CommonAuthAdapter`에서 `SUSPEND`도 `enabled=true`로 통과시키고, `LoginServiceImpl.loginCommon()`에서 인증 성공 직후 상태를 검사해 `MEMBER_4018`을 던집니다. Adapter의 `disabled` 처리로 막으면 비밀번호 검증 전에 차단되어 이메일 열거가 가능해지고 전용 에러 코드도 못 주기 때문입니다. 이때 `loadMember()`(lastLoginAt 갱신, deletedAt 자동 복구) 부수효과도 승인 전에는 실행되지 않습니다.

**컨트롤러 단일 유지 + 서비스 내부 분기** — 회원 상세는 `GET /members/{memberId}` 하나로 유지하고, `BackofficeMemberServiceImpl`이 role을 확인해 역할별 쿼리·DTO 매핑으로 분기합니다. 클라이언트가 role을 몰라도 memberId만으로 조회할 수 있습니다.

## 💬고민사항 및 리뷰 요구사항 (Optional)

- **승인 = 서류 검증 완료 간주**: approve 시 `isLicenseVerified`/`isSignVerified`를 함께 true 처리하도록 했습니다. 서류 검증과 계정 승인을 완전히 분리해야 한다면 approve에서 해당 처리를 제거하면 됩니다.
- **거절(INACTIVE) 후 재가입 플로우 없음**: 거절된 계정은 영구 로그인 불가 상태입니다. 재심사/재제출 플로우가 필요한지 의견 부탁드립니다.
- **탈퇴 회원 로그인 시 자동 복구 유지**: `CommonAuthAdapter.loadMember()`의 기존 자동 복구 동작은 그대로 두고, 백오피스 복구 API를 별도 경로로 추가했습니다. 두 경로가 공존해도 괜찮은지 확인 부탁드립니다.
- **프론트 영향**: Partner/Admin 가입 응답에서 `tokens`가 null이 되므로, 가입 직후 자동 로그인하던 클라이언트는 "승인 대기" 안내 화면으로 변경이 필요합니다. (`MEMBER_4018` 코드로 분기 가능)

## 비고 (Optional)

- 감사 로그 **조회** API(`GET /backoffice/audit-logs`)는 이번 범위에서 제외 (별도 작업 예정)
- Student는 uSaint 인증으로 즉시 `ACTIVE` 유지 (승인 대상 아님), 백오피스 회원 목록 조회에는 포함됨
- 운영 중 발견: `student.major` 컬럼이 MySQL `ENUM` 타입으로 생성되어 Java enum과 목록이 어긋나면 조회가 실패합니다 (`ddl-auto: update`는 기존 컬럼을 수정하지 않음). `VARCHAR`로 변경 후 데이터 보정으로 해결했으며, 다른 enum 컬럼도 동일 잠재 이슈가 있습니다.
