### PR TITLE
[FIX/#372] 관리자 신고 기능 api 구현

### DIFF
--- a/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeReportController.java
+++ b/src/main/java/com/assu/server/domain/backoffice/controller/BackofficeReportController.java
@@ -1,0 +1,60 @@
+package com.assu.server.domain.backoffice.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.assu.server.domain.backoffice.annotation.BackofficeAudited;
+import com.assu.server.domain.backoffice.dto.BackofficeReportResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeReportStatusUpdateRequestDTO;
+import com.assu.server.domain.backoffice.service.BackofficeReportService;
+import com.assu.server.global.apiPayload.BaseResponse;
+import com.assu.server.global.apiPayload.code.status.SuccessStatus;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Backoffice Report", description = "백오피스 신고 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backoffice/reports")
+@PreAuthorize("hasRole('BACKOFFICE')")
+public class BackofficeReportController {
+
+    private final BackofficeReportService backofficeReportService;
+
+    @BackofficeAudited(action = "REPORT_ALL_READ")
+    @Operation(summary = "모든 신고 목록 조회 API (백오피스용)", description = "시스템에 접수된 모든 신고 목록을 페이징 조회합니다.")
+    @GetMapping
+    public BaseResponse<Page<BackofficeReportResponseDTO>> getReports(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeReportService.getReports(pageable));
+    }
+
+    @BackofficeAudited(action = "REPORT_DETAIL_READ", targetId = "#reportId")
+    @Operation(summary = "신고 상세 조회 API (백오피스용)", description = "특정 신고 ID 기준 상세 내용을 조회합니다.")
+    @GetMapping("/{reportId}")
+    public BaseResponse<BackofficeReportResponseDTO> getReportDetail(
+            @PathVariable @Parameter(description = "신고 ID", required = true) Long reportId
+    ) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, backofficeReportService.getReportDetail(reportId));
+    }
+
+    @BackofficeAudited(action = "REPORT_STATUS_UPDATE", targetId = "#reportId")
+    @Operation(summary = "신고 상태 변경 및 기본 처리 API (백오피스용)", description = "신고의 처리 상태를 변경하고 관련 메모를 남깁니다.")
+    @PatchMapping("/{reportId}/status")
+    public BaseResponse<BackofficeReportResponseDTO> updateReportStatus(
+            @PathVariable @Parameter(description = "신고 ID", required = true) Long reportId,
+            @RequestBody @Valid BackofficeReportStatusUpdateRequestDTO req
+    ) {
+        BackofficeReportResponseDTO response = backofficeReportService.updateReportStatus(reportId, req);
+        return BaseResponse.onSuccess(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeReportResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeReportResponseDTO.java
@@ -1,0 +1,15 @@
+package com.assu.server.domain.backoffice.dto;
+
+import java.time.LocalDateTime;
+
+public record BackofficeReportResponseDTO(
+        Long reportId,
+        Long reporterId,
+        String reporterName,
+        String targetType,
+        Long targetId,
+        Long reason,
+        String content,
+        String status,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeReportStatusUpdateRequestDTO.java
+++ b/src/main/java/com/assu/server/domain/backoffice/dto/BackofficeReportStatusUpdateRequestDTO.java
@@ -1,0 +1,9 @@
+package com.assu.server.domain.backoffice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BackofficeReportStatusUpdateRequestDTO(
+        @NotBlank(message = "변경할 상태 값은 필수입니다.")
+        String status,
+        String memo
+) {}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeReportService.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeReportService.java
@@ -1,0 +1,13 @@
+package com.assu.server.domain.backoffice.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.assu.server.domain.backoffice.dto.BackofficeReportResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeReportStatusUpdateRequestDTO;
+
+public interface BackofficeReportService {
+    Page<BackofficeReportResponseDTO> getReports(Pageable pageable);
+    BackofficeReportResponseDTO getReportDetail(Long reportId);
+    BackofficeReportResponseDTO updateReportStatus(Long reportId, BackofficeReportStatusUpdateRequestDTO req);
+}

--- a/src/main/java/com/assu/server/domain/backoffice/service/BackofficeReportServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/backoffice/service/BackofficeReportServiceImpl.java
@@ -1,0 +1,89 @@
+package com.assu.server.domain.backoffice.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.assu.server.domain.backoffice.dto.BackofficeReportResponseDTO;
+import com.assu.server.domain.backoffice.dto.BackofficeReportStatusUpdateRequestDTO;
+import com.assu.server.domain.member.entity.Member;
+import com.assu.server.domain.report.entity.Report;
+import com.assu.server.domain.report.entity.enums.ReportStatus;
+import com.assu.server.domain.report.repository.ReportRepository;
+import com.assu.server.domain.auth.exception.CustomAuthException;
+import com.assu.server.global.apiPayload.code.status.ErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BackofficeReportServiceImpl implements BackofficeReportService {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<BackofficeReportResponseDTO> getReports(Pageable pageable) {
+        Page<Report> reports = reportRepository.findAll(pageable);
+        return reports.map(this::toResponseDTO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BackofficeReportResponseDTO getReportDetail(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_REPORT));
+        return toResponseDTO(report);
+    }
+
+    @Override
+    public BackofficeReportResponseDTO updateReportStatus(Long reportId, BackofficeReportStatusUpdateRequestDTO req) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomAuthException(ErrorStatus.NO_SUCH_REPORT));
+
+        ReportStatus nextStatus;
+        try {
+            nextStatus = ReportStatus.valueOf(req.status().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomAuthException(ErrorStatus._BAD_REQUEST);
+        }
+
+        report.updateStatus(nextStatus);
+
+        reportRepository.save(report);
+
+        return toResponseDTO(report);
+    }
+
+    private BackofficeReportResponseDTO toResponseDTO(Report report) {
+        String reporterName = extractName(report.getReporter());
+
+        return new BackofficeReportResponseDTO(
+                report.getId(),
+                report.getReporter() != null ? report.getReporter().getId() : null,
+                reporterName,
+                report.getTargetType() != null ? report.getTargetType().name() : null,
+                report.getTargetId(),
+                report.getReported() != null ? report.getReported().getId() : null,
+                report.getReportType() != null ? report.getReportType().name() : null,
+                report.getStatus() != null ? report.getStatus().name() : null,
+                report.getCreatedAt()
+        );
+    }
+
+
+    private String extractName(Member member) {
+        if (member == null || member.getRole() == null) {
+            return "탈퇴 사용자";
+        }
+
+        return switch (member.getRole()) {
+            case STUDENT -> (member.getStudentProfile() != null) ? member.getStudentProfile().getName() : "미등록 학생";
+            case ADMIN -> (member.getAdminProfile() != null) ? member.getAdminProfile().getName() : "미등록 관리자";
+            case PARTNER -> (member.getPartnerProfile() != null) ? member.getPartnerProfile().getName() : "미등록 파트너";
+            case BACKOFFICE -> (member.getBackofficeProfile() != null) ? member.getBackofficeProfile().getName() : "백오피스 운영자";
+        };
+    }
+}

--- a/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/assu/server/global/apiPayload/code/status/ErrorStatus.java
@@ -124,7 +124,9 @@ public enum ErrorStatus implements BaseErrorCode {
     REVIEW_REPORT_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT_4003", "자신의 리뷰를 신고할 수 없습니다."),
     SUGGESTION_REPORT_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT_4004", "자신의 건의글을 신고할 수 없습니다."),
     INVALID_REPORT_TYPE(HttpStatus.BAD_REQUEST, "REPORT_4005", "유효하지 않은 신고 타입입니다."),
-    NO_USAGE_DATA(HttpStatus.NOT_FOUND, "ADMIN4001", "해당 관리자의 제휴 이용 내역이 없습니다.");
+    NO_USAGE_DATA(HttpStatus.NOT_FOUND, "ADMIN4001", "해당 관리자의 제휴 이용 내역이 없습니다."),
+    NO_SUCH_REPORT(HttpStatus.NOT_FOUND, "REPORT_4006", "존재하지 않는 신고 ID입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #372 

## 📝작업 내용
> 백오피스 신고 관리 API 신규 구현

/backoffice/reports/ 엔드포인트

전체 신고 목록 페이징 조회 (GET /backoffice/reports)

단건 신고 상세 조회 (GET /backoffice/reports/{reportId})

신고 처리 상태 변경 및 업데이트 (PATCH /backoffice/reports/{reportId}/status)

