### PR TITLE
[FEAT/#383] GET /map/place 비인증 접근 허용

### DIFF
--- a/src/main/java/com/assu/server/domain/map/controller/MapController.java
+++ b/src/main/java/com/assu/server/domain/map/controller/MapController.java
@@ -22,7 +22,6 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/map")
-@PreAuthorize("hasAnyRole('STUDENT','ADMIN','PARTNER')")
 public class MapController {
 
     private final MapService mapService;
@@ -83,6 +82,7 @@ public class MapController {
                     "    - `longitude` (Double): 관리자 경도\n" +
                     "    - `profileUrl` (String): 관리자 카카오맵 Url\n" +
                     "    - `phoneNumber` (String): 관리자 전화번호\n")
+    @PreAuthorize("hasAnyRole('STUDENT','ADMIN','PARTNER')")
     @GetMapping("/nearby")
     public BaseResponse<?> getLocations(
             @ModelAttribute MapRequestDTO viewport,
@@ -148,6 +148,7 @@ public class MapController {
                     "    - `longitude` (Double): 관리자 경도\n" +
                     "    - `profileUrl` (String): 관리자 카카오맵 Url\n" +
                     "    - `phoneNumber` (String): 관리자 전화번호\n")
+    @PreAuthorize("hasAnyRole('STUDENT','ADMIN','PARTNER')")
     @GetMapping("/search")
     public BaseResponse<?> getLocationsByKeyword(
             @RequestParam("searchKeyword") @NotNull String keyword,

--- a/src/main/java/com/assu/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/assu/server/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                                 "/auth/students/login",
                                 "/auth/tokens/refresh",
                                 "/auth/backoffice/tokens/refresh",
-                                "/auth/students/ssu-verify"
+                                "/auth/students/ssu-verify",
+                                "/map/place"
                         ).permitAll()
                         .requestMatchers("/backoffice/**").hasRole("BACKOFFICE")
                         .requestMatchers("/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
## #️⃣연관된 이슈
> #383

## 📝작업 내용
> - `GET /map/place` (카카오맵 기반 장소 검색 API)를 인증 없이 호출 가능하도록 수정
> - SecurityConfig에 `/map/place` permitAll 추가
> - MapController 클래스 레벨 `@PreAuthorize` 제거 후 `/map/nearby`, `/map/search` 핸들러에 개별 적용

## 🔎코드 설명(스크린샷(선택))
> 기존에는 `MapController` 클래스 레벨에 `@PreAuthorize("hasAnyRole('STUDENT','ADMIN','PARTNER')")`가 걸려 있어 `/map/place`도 인증이 필요했습니다.
> 회원가입 플로우에서 주소 검색 시 사용하는 `/map/place`는 비인증 상태에서도 호출되어야 하므로, 클래스 레벨 어노테이션을 제거하고 인증이 필요한 `/map/nearby`, `/map/search`에만 개별적으로 `@PreAuthorize`를 붙였습니다.
> SecurityConfig에도 `/map/place`를 `permitAll()` 목록에 추가했습니다.

## 💬고민사항 및 리뷰 요구사항 (Optional)

## 비고 (Optional)