### PR TITLE
[FIX/#385] 알림 ALL 토글 버그 수정

### DIFF
--- a/src/main/java/com/assu/server/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/notification/service/NotificationCommandServiceImpl.java
@@ -77,12 +77,15 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NO_SUCH_MEMBER));
 
         if (type == NotificationType.PARTNER_ALL) {
-            toggleSingle(member, NotificationType.CHAT);
-            toggleSingle(member, NotificationType.ORDER);
+            // toggleSingle이 반전 후 새 값을 반환하므로, 그 값으로 하위 타입도 동일하게 설정
+            boolean newValue = toggleSingle(member, NotificationType.PARTNER_ALL);
+            setSingle(member, NotificationType.CHAT, newValue);
+            setSingle(member, NotificationType.ORDER, newValue);
         } else if (type == NotificationType.ADMIN_ALL) {
-            toggleSingle(member, NotificationType.CHAT);
-            toggleSingle(member, NotificationType.PARTNER_SUGGESTION);
-            toggleSingle(member, NotificationType.PARTNER_PROPOSAL);
+            boolean newValue = toggleSingle(member, NotificationType.ADMIN_ALL);
+            setSingle(member, NotificationType.CHAT, newValue);
+            setSingle(member, NotificationType.PARTNER_SUGGESTION, newValue);
+            setSingle(member, NotificationType.PARTNER_PROPOSAL, newValue);
         } else {
             toggleSingle(member, type);
         }
@@ -232,6 +235,22 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
     @Override
     public boolean isEnabled(Long memberId, NotificationType type) {
+        // ALL 스위치가 off이면 하위 타입도 전송 차단
+        // CHAT은 PARTNER_ALL(파트너) 또는 ADMIN_ALL(어드민) 둘 다 커버 가능 → 둘 다 체크
+        List<NotificationType> allTypes = switch (type) {
+            case CHAT -> List.of(NotificationType.PARTNER_ALL, NotificationType.ADMIN_ALL);
+            case ORDER -> List.of(NotificationType.PARTNER_ALL);
+            case PARTNER_SUGGESTION, PARTNER_PROPOSAL -> List.of(NotificationType.ADMIN_ALL);
+            default -> List.of();
+        };
+
+        for (NotificationType allType : allTypes) {
+            boolean allEnabled = notificationSettingRepository.findByMemberIdAndType(memberId, allType)
+                    .map(ns -> Boolean.TRUE.equals(ns.getEnabled()))
+                    .orElse(true);
+            if (!allEnabled) return false;
+        }
+
         return notificationSettingRepository.findByMemberIdAndType(memberId, type)
                 .map(ns -> Boolean.TRUE.equals(ns.getEnabled()))
                 .orElse(true);
@@ -251,10 +270,23 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         return setting.getEnabled();
     }
 
+    private void setSingle(Member member, NotificationType type, boolean enabled) {
+        NotificationSetting setting = notificationSettingRepository
+                .findByMemberIdAndType(member.getId(), type)
+                .orElse(NotificationSetting.builder()
+                        .member(member)
+                        .type(type)
+                        .enabled(true)
+                        .build());
+
+        setting.setEnabled(enabled);
+        notificationSettingRepository.save(setting);
+    }
+
     private Map<String, Boolean> buildToggleResult(Long memberId, UserRole role) {
         EnumSet<NotificationType> visibleTypes = switch(role) {
-            case ADMIN -> EnumSet.of(NotificationType.CHAT, NotificationType.PARTNER_SUGGESTION, NotificationType.PARTNER_PROPOSAL);
-            case PARTNER -> EnumSet.of(NotificationType.CHAT, NotificationType.ORDER);
+            case ADMIN -> EnumSet.of(NotificationType.ADMIN_ALL, NotificationType.CHAT, NotificationType.PARTNER_SUGGESTION, NotificationType.PARTNER_PROPOSAL);
+            case PARTNER -> EnumSet.of(NotificationType.PARTNER_ALL, NotificationType.CHAT, NotificationType.ORDER);
             case STUDENT -> EnumSet.of(NotificationType.STAMP);
             case BACKOFFICE -> EnumSet.noneOf(NotificationType.class);
         };


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #385

## 📝작업 내용
> ALL 토글 시 하위 알림 타입이 단순 반전되는 버그 수정
**버그 원인**
ALL 토글 시 `toggleSingle()`을 각 하위 타입에 개별 호출 → 이미 off인 타입이 on으로 반전되는 문제

**재현 시나리오**
- ALL on, 건의 off, 제안 off, 채팅 on 상태에서 ALL 토글
- 기대: ALL off, 채팅 off
- 실제: ALL off, 건의 on, 제안 on, 채팅 off (단순 반전)

**수정 내용**
- ALL 자체를 DB row로 저장하고, 반전된 새 값으로 하위 타입 전부 동일하게 설정
- `isEnabled()`에서 ALL이 off이면 하위 타입이 on이어도 알림 전송 차단
- `buildToggleResult()` 응답에 PARTNER_ALL / ADMIN_ALL 상태 포함