### PR TITLE
[FIX/#389] handleCertification 반환값 수정

### DIFF
--- a/src/main/java/com/assu/server/domain/certification/controller/GroupCertificationController.java
+++ b/src/main/java/com/assu/server/domain/certification/controller/GroupCertificationController.java
@@ -4,12 +4,12 @@ import java.security.Principal;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.assu.server.domain.certification.dto.CertificationProgressResponseDTO;
 import com.assu.server.domain.certification.dto.GroupSessionRequest;
 import com.assu.server.domain.certification.service.CertificationService;
 import com.assu.server.global.util.PrincipalDetails;
@@ -38,7 +38,7 @@ public class GroupCertificationController {
 			"  - `adminId` (Long, required): 인증하고자 하는 제휴의 관리자 ID\n" +
 			"  - `sessionId` (Long, required): 인증하고자 하는 그룹 세션 ID\n\n"
 	)
-	public void certifyGroup(@Payload GroupSessionRequest dto,
+	public CertificationProgressResponseDTO certifyGroup(@Payload GroupSessionRequest dto,
 		Principal principal) {
 		if (principal instanceof UsernamePasswordAuthenticationToken) {
 			UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken)principal;
@@ -49,11 +49,13 @@ public class GroupCertificationController {
 					principalDetails.getUsername(), dto.adminId(), dto.sessionId());
 
 				if (principalDetails != null) {
-					certificationService.handleCertification(dto, principalDetails.getMember());
+					return certificationService.handleCertification(dto, principalDetails.getMember());
 				}
 			} catch (Exception e) {
+				log.error("### ERROR ### 인증 처리 중 오류 발생: {}", e.getMessage(), e);
 			}
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/com/assu/server/domain/certification/service/CertificationService.java
+++ b/src/main/java/com/assu/server/domain/certification/service/CertificationService.java
@@ -2,6 +2,7 @@ package com.assu.server.domain.certification.service;
 
 import com.assu.server.domain.certification.dto.CertificationGroupRequestDTO;
 import com.assu.server.domain.certification.dto.CertificationPersonalRequestDTO;
+import com.assu.server.domain.certification.dto.CertificationProgressResponseDTO;
 import com.assu.server.domain.certification.dto.CertificationResponseDTO;
 import com.assu.server.domain.certification.dto.GroupSessionRequest;
 import com.assu.server.domain.member.entity.Member;
@@ -12,7 +13,7 @@ public interface CertificationService {
 
 	void expireSession(Long sessionId, Member member);
 
-	void handleCertification(GroupSessionRequest dto, Member member);
+	CertificationProgressResponseDTO handleCertification(GroupSessionRequest dto, Member member);
 
 	void certificatePersonal(CertificationPersonalRequestDTO dto, Member member);
 }

--- a/src/main/java/com/assu/server/domain/certification/service/CertificationServiceImpl.java
+++ b/src/main/java/com/assu/server/domain/certification/service/CertificationServiceImpl.java
@@ -83,7 +83,7 @@ public class CertificationServiceImpl implements CertificationService {
 	}
 
 	@Override
-	public void handleCertification(GroupSessionRequest dto, Member member) {
+	public CertificationProgressResponseDTO handleCertification(GroupSessionRequest dto, Member member) {
 		Long userId = member.getId();
 		Long sessionId = dto.sessionId();
 
@@ -99,12 +99,25 @@ public class CertificationServiceImpl implements CertificationService {
 		boolean matched = admins.stream().anyMatch(admin -> admin.getId().equals(dto.adminId()));
 
 		if (!matched) {
-			throw new IllegalArgumentException("학생과 매치되지 않는 정보입니다.");
+			List<Long> currentCertifiedUserIds = sessionManager.snapshotUserIds(sessionId);
+			CertificationProgressResponseDTO response = new CertificationProgressResponseDTO(
+				"fail",
+				currentCertifiedUserIds.size(),
+				"mismatch",
+				currentCertifiedUserIds
+			);
+			return response;
 		}
 
 		if (sessionManager.hasUser(sessionId, userId)) {
-			messagingTemplate.convertAndSend("/certification/progress/" + sessionId,
-				new CertificationProgressResponseDTO("progress", null, "doubled member", sessionManager.snapshotUserIds(sessionId)));
+			List<Long> currentCertifiedUserIds = sessionManager.snapshotUserIds(sessionId);
+			CertificationProgressResponseDTO response = new CertificationProgressResponseDTO(
+				"progress",
+				null,
+				"doubled member",
+				currentCertifiedUserIds
+			);
+			messagingTemplate.convertAndSend("/certification/progress/" + sessionId, response);
 			throw new GeneralException(ErrorStatus.DOUBLE_CERTIFIED_USER);
 		}
 
@@ -112,6 +125,7 @@ public class CertificationServiceImpl implements CertificationService {
 		List<Long> currentCertifiedUserIds = sessionManager.snapshotUserIds(sessionId);
 		int currentCount = currentCertifiedUserIds.size();
 
+		CertificationProgressResponseDTO response;
 		if (currentCount >= targetPeople) {
 			Store store = storeRepository.findById(storeId).orElseThrow(
 				() -> new GeneralException(ErrorStatus.NO_SUCH_STORE)
@@ -127,15 +141,17 @@ public class CertificationServiceImpl implements CertificationService {
 
 			associateCertificationRepository.save(certification);
 
-			messagingTemplate.convertAndSend("/certification/progress/" + sessionId,
-				new CertificationProgressResponseDTO("completed", currentCount, "인증 완료", currentCertifiedUserIds));
+			response = new CertificationProgressResponseDTO("completed", currentCount, "인증 완료", currentCertifiedUserIds);
+			messagingTemplate.convertAndSend("/certification/progress/" + sessionId, response);
 
 			sessionManager.removeSession(sessionId);
 		} else {
-			messagingTemplate.convertAndSend("/certification/progress/" + sessionId,
-				new CertificationProgressResponseDTO("progress", currentCount, null, currentCertifiedUserIds));
+			response = new CertificationProgressResponseDTO("progress", currentCount, null, currentCertifiedUserIds);
+			messagingTemplate.convertAndSend("/certification/progress/" + sessionId, response);
 		}
+		return response;
 	}
+
 	@Override
 	public void certificatePersonal(CertificationPersonalRequestDTO dto, Member member){
 		// store id 추출


### PR DESCRIPTION
## #️⃣연관된 이슈
> #389 

## 📝작업 내용
> `handleCertification` 에서 responseDto 추가
> 인증 에러 로그(임시) 추가

## 🔎코드 설명(스크린샷(선택))
> 일치하지 않은 제휴에 대해 그룹인증을 시도한 인증자를 구분하기 위해서 fail, mismatch 키워드를 보내는 것으로 수정



## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
